### PR TITLE
TextMagic Java Wrapper cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>textmagic-java-sdk</artifactId>
   <packaging>jar</packaging>
   <name>textmagic-java-sdk</name>
-  <version>1.0.1</version>
+  <version>1.2.0</version>
   <description>Java wrapper library for Textmagic services</description>
   <url>http://www.textmagic.com</url>
   <licenses>

--- a/readme.md
+++ b/readme.md
@@ -23,8 +23,8 @@ import java.util.Arrays;
 public class Example{
   public static void main(String[] args) throws RestException {
     RestClient client = new RestClient("<USERNAME>", "<APIV2_TOKEN>");
-          
-    TMNewMessage m = (TMNewMessage) client.getResource("TMNewMessage");
+
+    TMNewMessage m = client.getResource(TMNewMessage.class);
     m.setText("Hello from TextMagic Java");
     m.setPhones(Arrays.asList(new String[] {"99900000"}));
     try {
@@ -46,7 +46,7 @@ The easiest way to install the TextMagic Java wrapper is from Maven. You can add
 <dependency>
     <groupid>com.textmagic.sdk</groupid>
     <artifactid>textmagic-java-sdk</artifactid>
-    <version>1.0.0</version>
+    <version>1.2.0</version>
 </dependency>
 ```
 ### Manual Installation

--- a/src/main/java/com/textmagic/sdk/ClientException.java
+++ b/src/main/java/com/textmagic/sdk/ClientException.java
@@ -1,0 +1,26 @@
+package com.textmagic.sdk;
+
+/**
+ * Denotes error in the API wrapper code.
+ * Generally more serious than RestException.
+ * It denotes problems such as failure to create wrapper-specific objects or
+ * failure to parse response of the REST service.
+ * <p>
+ * Note: ClientException is unchecked.
+ *</p>
+ */
+public class ClientException extends RuntimeException {
+
+	/**
+	 * UID for serializer
+	 */
+	private static final long serialVersionUID = -6204810092210949132L;
+
+	public ClientException() {
+		super();
+	}
+	
+	public ClientException(Throwable t) {
+		super(t);
+	}
+}

--- a/src/main/java/com/textmagic/sdk/RequestMethod.java
+++ b/src/main/java/com/textmagic/sdk/RequestMethod.java
@@ -1,0 +1,9 @@
+package com.textmagic.sdk;
+
+/***
+ * Provides a list of supported HTTP request methods for TextMagic API.
+ *
+ */
+public enum RequestMethod {
+	GET, PUT, POST, DELETE
+}

--- a/src/main/java/com/textmagic/sdk/RestClient.java
+++ b/src/main/java/com/textmagic/sdk/RestClient.java
@@ -52,11 +52,6 @@ public class RestClient {
 	 */
 	public static final String PRODUCTION_URI = "https://api.textmagic.com/api/" + VERSION;
 
-	/**
-	 * URI for TextMagic API testing endpoint
-	 */
-	public static final String TESTING_URI = "https://api.textmagictesting.com/api/" + VERSION;
-
     /**
      * Username
      */
@@ -111,6 +106,19 @@ public class RestClient {
 
     /**
 	 * Instantiates REST client
+	 *
+	 * @param username API username
+	 * @param token API token
+	 * @param uri URI to the desired TextMagic endpoint
+	 */
+	public RestClient(final String username, final String token) {
+		this(username, token, PRODUCTION_URI);
+	}
+
+    /**
+	 * Instantiates REST client. This constructor allows to specify API URI for
+	 * accessing non-standard endpoints (e.g. mocked endpoint in a network where
+	 * internet is not accesible.
 	 *
 	 * @param username API username
 	 * @param token API token

--- a/src/main/java/com/textmagic/sdk/RestClient.java
+++ b/src/main/java/com/textmagic/sdk/RestClient.java
@@ -133,25 +133,25 @@ public class RestClient {
 	 *
 	 * @param clazz Class to instantiate
 	 * @return Resource object
-	 * @throws RuntimeException exception when class instance can not be created
+	 * @throws ClientException exception when class instance can not be created
 	 */
-	public <T extends Resource<RestClient>> T getResource(Class<T> clazz) throws RuntimeException {
+	public <T extends Resource<RestClient>> T getResource(Class<T> clazz) throws ClientException {
 		try {
 			return clazz
 				.getConstructor(RestClient.class)
 				.newInstance(this);
 		} catch (final InstantiationException e) {
-			throw new RuntimeException(e);
+			throw new ClientException(e);
 		} catch (final IllegalAccessException e) {
-			throw new RuntimeException(e);
+			throw new ClientException(e);
 		} catch (final IllegalArgumentException e) {
-			throw new RuntimeException(e);
+			throw new ClientException(e);
 		} catch (final InvocationTargetException e) {
-			throw new RuntimeException(e);
+			throw new ClientException(e);
 		} catch (final NoSuchMethodException e) {
-			throw new RuntimeException(e);
+			throw new ClientException(e);
 		} catch (final SecurityException e) {
-			throw new RuntimeException(e);
+			throw new ClientException(e);
 		}
 	}
 	
@@ -161,25 +161,25 @@ public class RestClient {
 	 * @param clazz Class to instantiate
 	 * @param parameters Parameters
 	 * @return Resource object
-	 * @throws RuntimeException exception when class instance can not be created
+	 * @throws ClientException exception when class instance can not be created
 	 */
-	public <T extends Resource<RestClient>> T getResource(Class<T> clazz, Map<String, String> parameters) throws RuntimeException {
+	public <T extends Resource<RestClient>> T getResource(Class<T> clazz, Map<String, String> parameters) throws ClientException {
 		try {
 			return clazz
 				.getConstructor(RestClient.class, Map.class)
 				.newInstance(this, parameters);
 		} catch (final InstantiationException e) {
-			throw new RuntimeException(e);
+			throw new ClientException(e);
 		} catch (final IllegalAccessException e) {
-			throw new RuntimeException(e);
+			throw new ClientException(e);
 		} catch (final IllegalArgumentException e) {
-			throw new RuntimeException(e);
+			throw new ClientException(e);
 		} catch (final InvocationTargetException e) {
-			throw new RuntimeException(e);
+			throw new ClientException(e);
 		} catch (final NoSuchMethodException e) {
-			throw new RuntimeException(e);
+			throw new ClientException(e);
 		} catch (final SecurityException e) {
-			throw new RuntimeException(e);
+			throw new ClientException(e);
 		}
 	}
 	
@@ -261,7 +261,7 @@ public class RestClient {
 		try {
 			entity = new UrlEncodedFormEntity(paramList, "UTF-8");
 		} catch (final UnsupportedEncodingException e) {
-			throw new RuntimeException(e);
+			throw new ClientException(e);
 		}
 
 		return entity;
@@ -343,9 +343,9 @@ public class RestClient {
 	 * @param paramList Request params
 	 * @return Textmagic response instance
      * @throws RestException exception when API request results in error (HTTP error codes in 3xx or 4xx)
-     * @throws RuntimeException exception when network or protocol error is encountered
+     * @throws ClientException exception when network or protocol error is encountered
 	 */
-	public RestResponse request(final String path, final RequestMethod method, final List<NameValuePair> paramList) throws RestException, RuntimeException {
+	public RestResponse request(final String path, final RequestMethod method, final List<NameValuePair> paramList) throws RestException, ClientException {
 		if (path == null && method == null && paramList == null) {
 			return new RestResponse("", 0);
 		}
@@ -382,9 +382,9 @@ public class RestClient {
 			
 			throw RestException.parseResponse(result);
 		} catch (final ClientProtocolException e1) {
-			throw new RuntimeException(e1);
+			throw new ClientException(e1);
 		} catch (final IOException e1) {
-			throw new RuntimeException(e1);
+			throw new ClientException(e1);
 		}
 	}
 

--- a/src/main/java/com/textmagic/sdk/RestClient.java
+++ b/src/main/java/com/textmagic/sdk/RestClient.java
@@ -133,29 +133,27 @@ public class RestClient {
 	 *
 	 * @param clazz Class to instantiate
 	 * @return Resource object
+	 * @throws RuntimeException exception when class instance can not be created
 	 */
-	public <T extends Resource<RestClient>> T getResource(Class<T> clazz) {
-		T resource = null;
+	public <T extends Resource<RestClient>> T getResource(Class<T> clazz) throws RuntimeException {
 		try {
-			resource = clazz
+			return clazz
 				.getConstructor(RestClient.class)
 				.newInstance(this);
-		} catch (InstantiationException e) {
-			e.printStackTrace();
-		} catch (IllegalAccessException e) {
-			e.printStackTrace();
-		} catch (IllegalArgumentException e) {
-			e.printStackTrace();
-		} catch (InvocationTargetException e) {
-			e.printStackTrace();
-		} catch (NoSuchMethodException e) {
-			e.printStackTrace();
-		} catch (SecurityException e) {
-			e.printStackTrace();
+		} catch (final InstantiationException e) {
+			throw new RuntimeException(e);
+		} catch (final IllegalAccessException e) {
+			throw new RuntimeException(e);
+		} catch (final IllegalArgumentException e) {
+			throw new RuntimeException(e);
+		} catch (final InvocationTargetException e) {
+			throw new RuntimeException(e);
+		} catch (final NoSuchMethodException e) {
+			throw new RuntimeException(e);
+		} catch (final SecurityException e) {
+			throw new RuntimeException(e);
 		}
-		
-		return resource;
-	}	
+	}
 	
 	/**
 	 * Retrieve resource object
@@ -163,29 +161,27 @@ public class RestClient {
 	 * @param clazz Class to instantiate
 	 * @param parameters Parameters
 	 * @return Resource object
+	 * @throws RuntimeException exception when class instance can not be created
 	 */
-	public <T extends Resource<RestClient>> T getResource(Class<T> clazz, Map<String, String> parameters) {
-		T resource = null;
+	public <T extends Resource<RestClient>> T getResource(Class<T> clazz, Map<String, String> parameters) throws RuntimeException {
 		try {
-			resource = clazz
+			return clazz
 				.getConstructor(RestClient.class, Map.class)
 				.newInstance(this, parameters);
-		} catch (InstantiationException e) {
-			e.printStackTrace();
-		} catch (IllegalAccessException e) {
-			e.printStackTrace();
-		} catch (IllegalArgumentException e) {
-			e.printStackTrace();
-		} catch (InvocationTargetException e) {
-			e.printStackTrace();
-		} catch (NoSuchMethodException e) {
-			e.printStackTrace();
-		} catch (SecurityException e) {
-			e.printStackTrace();
+		} catch (final InstantiationException e) {
+			throw new RuntimeException(e);
+		} catch (final IllegalAccessException e) {
+			throw new RuntimeException(e);
+		} catch (final IllegalArgumentException e) {
+			throw new RuntimeException(e);
+		} catch (final InvocationTargetException e) {
+			throw new RuntimeException(e);
+		} catch (final NoSuchMethodException e) {
+			throw new RuntimeException(e);
+		} catch (final SecurityException e) {
+			throw new RuntimeException(e);
 		}
-		
-		return resource;
-	}		
+	}
 	
 	/**
 	 * Build get request
@@ -346,9 +342,10 @@ public class RestClient {
 	 * @param method Request method
 	 * @param paramList Request params
 	 * @return Textmagic response instance
-     * @throws RestException exception
+     * @throws RestException exception when API request results in error (HTTP error codes in 3xx or 4xx)
+     * @throws RuntimeException exception when network or protocol error is encountered
 	 */
-	public RestResponse request(final String path, final RequestMethod method, final List<NameValuePair> paramList) throws RestException {
+	public RestResponse request(final String path, final RequestMethod method, final List<NameValuePair> paramList) throws RestException, RuntimeException {
 		if (path == null && method == null && paramList == null) {
 			return new RestResponse("", 0);
 		}
@@ -427,7 +424,7 @@ public class RestClient {
 		path = sb.toString();
 
 		HttpUriRequest request;
-        
+
 		switch(method) {
 		case GET:
 			request = buildGetRequest(path, params);

--- a/src/main/java/com/textmagic/sdk/RestClient.java
+++ b/src/main/java/com/textmagic/sdk/RestClient.java
@@ -52,6 +52,8 @@ public class RestClient {
 	 */
 	public static final String PRODUCTION_URI = "https://rest.textmagic.com/api/" + VERSION;
 
+	private static final int TIMEOUT = 1000;
+
     /**
      * Username
      */
@@ -363,9 +365,9 @@ public class RestClient {
 		HttpResponse response;
 		try {
 	        long requestTimeDiff = new java.util.Date().getTime() - previousRequestTime;
-			if (requestTimeDiff < 500) {
+			if (requestTimeDiff < TIMEOUT) {
 	            try {
-					Thread.sleep(500 - requestTimeDiff);
+					Thread.sleep(TIMEOUT - requestTimeDiff);
 				} catch (InterruptedException e) {
 					e.printStackTrace();
 				}

--- a/src/main/java/com/textmagic/sdk/RestClient.java
+++ b/src/main/java/com/textmagic/sdk/RestClient.java
@@ -50,7 +50,7 @@ public class RestClient {
 	/**
 	 * URI for TextMagic API production endpoint
 	 */
-	public static final String PRODUCTION_URI = "https://api.textmagic.com/api/" + VERSION;
+	public static final String PRODUCTION_URI = "https://rest.textmagic.com/api/" + VERSION;
 
     /**
      * Username

--- a/src/main/java/com/textmagic/sdk/RestClient.java
+++ b/src/main/java/com/textmagic/sdk/RestClient.java
@@ -42,11 +42,20 @@ class HttpDeleteEntity extends HttpPost {
 }
 
 public class RestClient {
-
-    /**
+	/**
      * Used version
      */
-	private static final String version = "v2";
+	private static final String VERSION = "v2";
+
+	/**
+	 * URI for TextMagic API production endpoint
+	 */
+	public static final String PRODUCTION_URI = "https://api.textmagic.com/api/" + VERSION;
+
+	/**
+	 * URI for TextMagic API testing endpoint
+	 */
+	public static final String TESTING_URI = "https://api.textmagic.com/api/" + VERSION;
 
     /**
      * Username
@@ -58,6 +67,11 @@ public class RestClient {
      */
 	private final String token;
 
+	/**
+	 * URI for TextMagic REST API
+	 */
+	private final String uri;
+
     /**
      * Http client instance
      */
@@ -67,14 +81,14 @@ public class RestClient {
      * Previous request time for prevent limit exceed error
      */    
     protected long previousRequestTime = 0;	
-	
+
 	/**
 	 * Retrieve API URI
 	 *
 	 * @return API URI
 	 */
 	public String getApiUri() {
-		return "https://api.textmagictesting.com/api/" + version;
+		return uri;
 	}
     
 	/**
@@ -94,16 +108,18 @@ public class RestClient {
 	public void setHttpClient(final HttpClient client) {
 		this.client = client;
 	}
-    
+
     /**
 	 * Instantiates REST client
 	 *
 	 * @param username API username
 	 * @param token API token
+	 * @param uri URI to the desired TextMagic endpoint
 	 */
-	public RestClient(final String username, final String token) {
+	public RestClient(final String username, final String token, final String uri) {
 		this.username = username;
 		this.token = token;
+		this.uri = uri;
 
 		setHttpClient(new DefaultHttpClient());
 		client.getParams().setParameter("http.protocol.version", HttpVersion.HTTP_1_1);
@@ -429,7 +445,7 @@ public class RestClient {
 			throw new IllegalArgumentException("Unknown Method: " + method);
 		}
 
-		request.addHeader(new BasicHeader("User-Agent", "textmagic-rest-java/" + version));
+		request.addHeader(new BasicHeader("User-Agent", "textmagic-rest-java/" + VERSION));
 		request.addHeader(new BasicHeader("Accept", "application/json"));
 		request.addHeader(new BasicHeader("Accept-Charset", "utf-8"));
 		request.addHeader(new BasicHeader("Accept-Language", "en-US"));

--- a/src/main/java/com/textmagic/sdk/RestClient.java
+++ b/src/main/java/com/textmagic/sdk/RestClient.java
@@ -19,6 +19,8 @@ import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 
+import com.textmagic.sdk.resource.Resource;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
@@ -113,13 +115,13 @@ public class RestClient {
 	/**
 	 * Retrieve resource object
 	 *
-	 * @param name Name
+	 * @param clazz Class to instantiate
 	 * @return Resource object
 	 */
-	public Object getResource(String name) {
-		Object resource = null;
+	public <T extends Resource<RestClient>> T getResource(Class<T> clazz) {
+		T resource = null;
 		try {
-			resource = Class.forName("com.textmagic.sdk.resource.instance." + name)
+			resource = clazz
 				.getConstructor(RestClient.class)
 				.newInstance(this);
 		} catch (InstantiationException e) {
@@ -134,8 +136,6 @@ public class RestClient {
 			e.printStackTrace();
 		} catch (SecurityException e) {
 			e.printStackTrace();
-		} catch (ClassNotFoundException e) {
-			e.printStackTrace();
 		}
 		
 		return resource;
@@ -144,14 +144,14 @@ public class RestClient {
 	/**
 	 * Retrieve resource object
 	 *
-	 * @param name Name
+	 * @param clazz Class to instantiate
 	 * @param parameters Parameters
 	 * @return Resource object
 	 */
-	public Object getResource(String name, Map<String, String> parameters) {
-		Object resource = null;
+	public <T extends Resource<RestClient>> T getResource(Class<T> clazz, Map<String, String> parameters) {
+		T resource = null;
 		try {
-			resource = Class.forName("com.textmagic.sdk.resource.instance." + name)
+			resource = clazz
 				.getConstructor(RestClient.class, Map.class)
 				.newInstance(this, parameters);
 		} catch (InstantiationException e) {
@@ -165,8 +165,6 @@ public class RestClient {
 		} catch (NoSuchMethodException e) {
 			e.printStackTrace();
 		} catch (SecurityException e) {
-			e.printStackTrace();
-		} catch (ClassNotFoundException e) {
 			e.printStackTrace();
 		}
 		

--- a/src/main/java/com/textmagic/sdk/RestClient.java
+++ b/src/main/java/com/textmagic/sdk/RestClient.java
@@ -55,7 +55,7 @@ public class RestClient {
 	/**
 	 * URI for TextMagic API testing endpoint
 	 */
-	public static final String TESTING_URI = "https://api.textmagic.com/api/" + VERSION;
+	public static final String TESTING_URI = "https://api.textmagictesting.com/api/" + VERSION;
 
     /**
      * Username

--- a/src/main/java/com/textmagic/sdk/RestClient.java
+++ b/src/main/java/com/textmagic/sdk/RestClient.java
@@ -317,7 +317,7 @@ public class RestClient {
 	 * @return Textmagic response instance
      * @throws RestException exception
 	 */
-	public RestResponse request(final String path, final String method) throws RestException {
+	public RestResponse request(final String path, final RequestMethod method) throws RestException {
 		Map<String, String> param = new HashMap<String, String>();
 		
 		return request(path, method, param);
@@ -332,7 +332,7 @@ public class RestClient {
 	 * @return Textmagic response instance
      * @throws RestException exception
 	 */
-	public RestResponse request(final String path, final String method, final List<NameValuePair> paramList) throws RestException {
+	public RestResponse request(final String path, final RequestMethod method, final List<NameValuePair> paramList) throws RestException {
 		if (path == null && method == null && paramList == null) {
 			return new RestResponse("", 0);
 		}
@@ -384,7 +384,7 @@ public class RestClient {
 	 * @return Textmagic response instance
      * @throws RestException exception
 	 */
-	public RestResponse request(final String path, final String method, final Map<String, String> paramMap) throws RestException {
+	public RestResponse request(final String path, final RequestMethod method, final Map<String, String> paramMap) throws RestException {
 		List<NameValuePair> paramList = buildParametersList(paramMap);
         
 		return request(path, method, paramList);
@@ -398,7 +398,7 @@ public class RestClient {
 	 * @param params Request params
 	 * @return HTTP request instance
 	 */
-	private HttpUriRequest buildRequest(final String method, String path, final List<NameValuePair> params) {
+	private HttpUriRequest buildRequest(final RequestMethod method, String path, final List<NameValuePair> params) {
 		String normalizedPath = path.toLowerCase();
 		StringBuilder sb = new StringBuilder();
 
@@ -412,15 +412,20 @@ public class RestClient {
 
 		HttpUriRequest request;
         
-        if (method.equalsIgnoreCase("GET")) {
+		switch(method) {
+		case GET:
 			request = buildGetRequest(path, params);
-		} else if (method.equalsIgnoreCase("POST")) {
+			break;
+		case POST:
 			request = buildPostRequest(path, params);
-		} else if (method.equalsIgnoreCase("PUT")) {
+			break;
+		case PUT:
 			request = buildPutRequest(path, params);
-		} else if (method.equalsIgnoreCase("DELETE")) {
+			break;
+		case DELETE:
 			request = buildDeleteRequest(path, params);
-		} else {
+			break;
+		default:
 			throw new IllegalArgumentException("Unknown Method: " + method);
 		}
 

--- a/src/main/java/com/textmagic/sdk/RestClient.java
+++ b/src/main/java/com/textmagic/sdk/RestClient.java
@@ -52,7 +52,7 @@ public class RestClient {
 	 */
 	public static final String PRODUCTION_URI = "https://rest.textmagic.com/api/" + VERSION;
 
-	private static final int TIMEOUT = 1000;
+	private static final int TIMEOUT = 500;
 
     /**
      * Username

--- a/src/main/java/com/textmagic/sdk/RestException.java
+++ b/src/main/java/com/textmagic/sdk/RestException.java
@@ -1,7 +1,13 @@
 package com.textmagic.sdk;
 
 import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.lang.text.StrBuilder;
+
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 public class RestException extends Exception {
 
@@ -9,6 +15,8 @@ public class RestException extends Exception {
 	 * UID for serializer
 	 */
 	private static final long serialVersionUID = -617296495882003033L;
+	
+	private static final String KEY_SEPARATOR = " ";
 
 	/**
      * Error code
@@ -23,7 +31,7 @@ public class RestException extends Exception {
     /**
      * Fields errors
      */
-	private Map<String, ArrayList<String>> errors;
+	private Map<String, List<String>> errors;
 	
 	/**
 	 * Instantiates rest exception
@@ -42,7 +50,7 @@ public class RestException extends Exception {
 	 * @param code Error code
 	 * @param errors Fields errors
 	 */
-	public RestException(String message, Integer code, Map<String, ArrayList<String>> errors) {
+	public RestException(String message, Integer code, Map<String, List<String>> errors) {
 		super(message);
 
 		this.message = message;
@@ -61,7 +69,7 @@ public class RestException extends Exception {
 		Map<String, Object> data = response.toMap();
 		Integer code = 0;
 		String message = "";
-		Map<String, ArrayList<String>> errors = null;
+		Map<String, List<String>> errors = new HashMap<String, List<String>>();
 		
 		message = (String) data.get("message");
 			
@@ -69,10 +77,56 @@ public class RestException extends Exception {
 			code = (Integer) data.get("code");
 		}
 		if (data.get("errors") != null) {
-			errors = (Map<String, ArrayList<String>>) data.get("errors");
+			addErrors("", (Map<String, Object>) data.get("errors"), errors);
 		}
 
 		return new RestException(message, code, errors);
+	}
+
+	/**
+	 * Recursively iterates through nested maps, until either List or plain object is encountered.
+	 * <p>
+	 * If map element's value is a Map, calls self recursively, passing Map's value as restErrors.
+	 * The prefix value is constructed by taking the current prefix, adding KEY_SEPARATOR and current key.
+	 * </p>
+	 * <p>
+	 * If map element's value is a List, converts each Lists element to String and puts resulting List of to result map.
+	 * </p>
+	 * <p>
+	 * If map element's value is neither List nor Map, converts the Object to String and adds a single element List to result map.
+	 * </p>
+	 *
+	 * @param prefix is used as a part of key for objects added into result map
+	 * @param restErrors Map which is iterated upon
+	 * @param result is used to store the generated results
+	 */
+	@SuppressWarnings("unchecked")
+	private static void addErrors(String prefix, Map<String, Object> restErrors, Map<String, List<String>> result) {
+		// At this point we don't know what the map contains
+		// We assume that keys are Strings, and recursively descend the map checking each level's values for type.
+		// If value type is not a Map, we return the result map, which is then used to construct the result on a higher level
+		for (Entry<String, Object> entry : restErrors.entrySet()) {
+			String key = entry.getKey();
+			Object value = entry.getValue();
+			String resultKey = prefix.length() == 0 ? key : prefix + KEY_SEPARATOR + key;
+			if (value instanceof Map) {
+				addErrors(resultKey, (Map<String, Object>) value, result);
+				continue;
+			}
+			if (value instanceof List) {
+				List<String> list = new ArrayList<String>();
+				for (Object v : (List<Object>) value) {
+					list.add(v.toString());
+				}
+				result.put(resultKey, list);
+				continue;
+			}
+			// Value is not a list or map - get it's String representation and put it in a list.
+			List<String> list = new ArrayList<String>(1);
+			String msg = value != null ? value.toString() : "null";
+			list.add(msg);
+			result.put(resultKey, list);
+		}
 	}
 
 	/**
@@ -98,7 +152,29 @@ public class RestException extends Exception {
 	 *
 	 * @return Fields errors
 	 */
-	public Map<String, ArrayList<String>> getErrors() {
+	public Map<String, List<String>> getErrors() {
 		return errors;
+	}
+
+	/**
+	 * Retrieve textual representation of exception data:<br>
+	 * <ol>
+	 * <li> Error code returned by server<br>
+	 * <li> Error message<br>
+	 * <li> Error list
+	 * </ol
+	 * @return textual representation of Exception data
+	 */
+	public String getTextRepresentation() {
+		StrBuilder sb = new StrBuilder();
+		sb.append("RestException[\n\t");
+		sb.append(message).append("\n\t");
+		for(Entry<String, List<String>> msgs : errors.entrySet()) {
+			sb.append(msgs.getKey()).append(" => [");
+			sb.appendWithSeparators(msgs.getValue(), "\n\t\t");
+			sb.append("]\n\t"); 
+		}
+		sb.setLength(sb.length() - 1);
+		return sb.append("]").toString();
 	}
 }

--- a/src/main/java/com/textmagic/sdk/RestResponse.java
+++ b/src/main/java/com/textmagic/sdk/RestResponse.java
@@ -70,6 +70,7 @@ public class RestResponse {
 	 * Retrieve map container from JSON response
 	 *
 	 * @return Map container with repeated elements as List values, sub-objects as Map values. All other types are String values.
+	 * @throws ClientException when parsing API response fails
 	 */
 	@SuppressWarnings("unchecked")
 	public Map<String, Object> toMap() throws ClientException {
@@ -92,6 +93,7 @@ public class RestResponse {
 	 * Retrieve list container from JSON response
 	 *
 	 * @return List container with repeated elements as list values.
+	 * @throws ClientException when parsing API response fails
 	 */
     @SuppressWarnings("unchecked")
 	public List<Object> toList() throws ClientException {

--- a/src/main/java/com/textmagic/sdk/RestResponse.java
+++ b/src/main/java/com/textmagic/sdk/RestResponse.java
@@ -72,17 +72,17 @@ public class RestResponse {
 	 * @return Map container with repeated elements as List values, sub-objects as Map values. All other types are String values.
 	 */
 	@SuppressWarnings("unchecked")
-	public Map<String, Object> toMap() {
+	public Map<String, Object> toMap() throws ClientException {
 		Map<String, Object> result = new HashMap<String, Object>();
 
 		try {
 			result = new ObjectMapper().readValue(jsonResponse, HashMap.class);
 		} catch (JsonParseException e) {
-			e.printStackTrace();
+			throw new ClientException(e);
 		} catch (JsonMappingException e) {
-			e.printStackTrace();
+			throw new ClientException(e);
 		} catch (IOException e) {
-			e.printStackTrace();
+			throw new ClientException(e);
 		}
 
 		return result;
@@ -94,17 +94,17 @@ public class RestResponse {
 	 * @return List container with repeated elements as list values.
 	 */
     @SuppressWarnings("unchecked")
-	public List<Object> toList() {
+	public List<Object> toList() throws ClientException {
 		List<Object> result = new ArrayList<Object>();
 
 		try {
 			result = new ObjectMapper().readValue(jsonResponse, List.class);
 		} catch (JsonParseException e) {
-			e.printStackTrace();
+			throw new ClientException(e);
 		} catch (JsonMappingException e) {
-			e.printStackTrace();
+			throw new ClientException(e);
 		} catch (IOException e) {
-			e.printStackTrace();
+			throw new ClientException(e);
 		}
 
 		return result;

--- a/src/main/java/com/textmagic/sdk/resource/InstanceResource.java
+++ b/src/main/java/com/textmagic/sdk/resource/InstanceResource.java
@@ -1,10 +1,16 @@
 package com.textmagic.sdk.resource;
 
+import com.textmagic.sdk.RequestMethod;
 import com.textmagic.sdk.RestClient;
 import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
 import org.apache.commons.lang.time.DateUtils;
 import org.apache.commons.lang.time.DateFormatUtils;
+
+import static com.textmagic.sdk.RequestMethod.DELETE;
+import static com.textmagic.sdk.RequestMethod.GET;
+import static com.textmagic.sdk.RequestMethod.POST;
+import static com.textmagic.sdk.RequestMethod.PUT;
 
 import java.text.ParseException;
 import java.util.Date;
@@ -117,7 +123,7 @@ public abstract class InstanceResource<C extends RestClient> extends Resource<C>
 	 */
 	public boolean get(Integer id) throws RestException {
 		if (properties.size() == 0) {
-            RestResponse response = getClient().request(getResourcePath() + '/' + id, "GET");
+            RestResponse response = getClient().request(getResourcePath() + '/' + id, GET);
             this.properties = new HashMap<String, Object>(response.toMap());
             
             return !response.isError();
@@ -134,13 +140,13 @@ public abstract class InstanceResource<C extends RestClient> extends Resource<C>
 	 */
 	public boolean createOrUpdate() throws RestException {
 		String resourcePath = null;
-		String method = null;
+		RequestMethod method = null;
 		
 		if (getProperty("id") == null) {
-			method = "POST";
+			method = POST;
 			resourcePath = getResourcePath();
 		} else {
-			method = "PUT";
+			method = PUT;
 			resourcePath = getResourcePath() + '/' + getProperty("id");
 		}
 		
@@ -161,7 +167,7 @@ public abstract class InstanceResource<C extends RestClient> extends Resource<C>
 		if (getProperty("id") == null) {
 			throw new UnsupportedOperationException("This operation is unsupported for non existent objects");
 		} else {
-			RestResponse response = getClient().request(getResourcePath() + '/' + getProperty("id"), "DELETE");
+			RestResponse response = getClient().request(getResourcePath() + '/' + getProperty("id"), DELETE);
             clearProperties();
             
             return !response.isError();

--- a/src/main/java/com/textmagic/sdk/resource/InstanceResource.java
+++ b/src/main/java/com/textmagic/sdk/resource/InstanceResource.java
@@ -1,5 +1,6 @@
 package com.textmagic.sdk.resource;
 
+import com.textmagic.sdk.ClientException;
 import com.textmagic.sdk.RequestMethod;
 import com.textmagic.sdk.RestClient;
 import com.textmagic.sdk.RestException;
@@ -119,9 +120,10 @@ public abstract class InstanceResource<C extends RestClient> extends Resource<C>
 	 *
 	 * @param id Resource item id
 	 * @return Error state
-	 * @throws RestException exception
+	 * @throws RestException exception when TextMagic REST API returns an error
+	 * @throws ClientException when error occurs on client side
 	 */
-	public boolean get(Integer id) throws RestException {
+	public boolean get(Integer id) throws RestException, ClientException {
 		if (properties.size() == 0) {
             RestResponse response = getClient().request(getResourcePath() + '/' + id, GET);
             this.properties = new HashMap<String, Object>(response.toMap());
@@ -136,9 +138,10 @@ public abstract class InstanceResource<C extends RestClient> extends Resource<C>
 	 * Create or update resource item
      *
      * @return Error state
-	 * @throws RestException exception
+	 * @throws RestException exception when TextMagic REST API returns an error
+	 * @throws ClientException when error occurs on client side
 	 */
-	public boolean createOrUpdate() throws RestException {
+	public boolean createOrUpdate() throws RestException, ClientException {
 		String resourcePath = null;
 		RequestMethod method = null;
 		
@@ -161,9 +164,10 @@ public abstract class InstanceResource<C extends RestClient> extends Resource<C>
 	 * Delete resource item
      *
      * @return Error state
-	 * @throws RestException exception
+	 * @throws RestException exception when TextMagic REST API returns an error
+	 * @throws ClientException when error occurs on client side
 	 */
-	public boolean delete() throws RestException {
+	public boolean delete() throws RestException, ClientException {
 		if (getProperty("id") == null) {
 			throw new UnsupportedOperationException("This operation is unsupported for non existent objects");
 		} else {

--- a/src/main/java/com/textmagic/sdk/resource/InstanceResource.java
+++ b/src/main/java/com/textmagic/sdk/resource/InstanceResource.java
@@ -14,6 +14,7 @@ import static com.textmagic.sdk.RequestMethod.POST;
 import static com.textmagic.sdk.RequestMethod.PUT;
 
 import java.text.ParseException;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -84,8 +85,16 @@ public abstract class InstanceResource<C extends RestClient> extends Resource<C>
 	 */
 	protected void setProperty(String name, Object value) {
 		properties.put(name, value);
-	}    
-    
+	}
+
+	/**
+	 * Get immutable representation of properties
+	 * @return
+	 */
+	protected Map<String, Object> getProperties() {
+		return Collections.unmodifiableMap(properties);
+	}
+
 	/**
 	 * Retrieve resource date property
      *
@@ -176,5 +185,18 @@ public abstract class InstanceResource<C extends RestClient> extends Resource<C>
             
             return !response.isError();
 		}
+	}
+
+	/**
+	 * Objects are equal if property Maps are equal
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof InstanceResource) {
+			@SuppressWarnings("unchecked")
+			InstanceResource<RestClient> other = (InstanceResource<RestClient>) obj;
+			return getProperties().equals(other.getProperties());
+		}
+		return super.equals(obj);
 	}
 }

--- a/src/main/java/com/textmagic/sdk/resource/ListResource.java
+++ b/src/main/java/com/textmagic/sdk/resource/ListResource.java
@@ -1,5 +1,6 @@
 package com.textmagic.sdk.resource;
 
+import com.textmagic.sdk.ClientException;
 import com.textmagic.sdk.RestClient;
 import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
@@ -36,7 +37,7 @@ public abstract class ListResource<T extends Resource, C extends RestClient> ext
 			try {
 				fetchNextPage();
 			} catch (RestException e) {
-				throw new RuntimeException(e);
+				throw new ClientException(e);
 			}
 
 			itr = pageData.iterator();
@@ -95,7 +96,7 @@ public abstract class ListResource<T extends Resource, C extends RestClient> ext
 		try {
 			return new ListIterator(getPageData().iterator());
 		} catch (RestException e) {
-			throw new RuntimeException(e);
+			throw new ClientException(e);
 		}
 	}
 

--- a/src/main/java/com/textmagic/sdk/resource/ListResource.java
+++ b/src/main/java/com/textmagic/sdk/resource/ListResource.java
@@ -115,7 +115,7 @@ public abstract class ListResource<T extends Resource, C extends RestClient> ext
 	 * @throws RestException exception
 	 */
     @SuppressWarnings("unchecked")
-	protected void getListContent() throws RestException {
+	protected void getListContent() throws RestException, ClientException {
 		parameters.put("page", Integer.toString(this.page));
         parameters.put("limit", Integer.toString(this.limit));
 		

--- a/src/main/java/com/textmagic/sdk/resource/ListResource.java
+++ b/src/main/java/com/textmagic/sdk/resource/ListResource.java
@@ -4,6 +4,8 @@ import com.textmagic.sdk.RestClient;
 import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
 
+import static com.textmagic.sdk.RequestMethod.GET;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -122,7 +124,7 @@ public abstract class ListResource<T extends Resource, C extends RestClient> ext
 			sb.append("/search");
 		}
 
-        RestResponse response = getClient().request(sb.toString(), "GET", parameters);
+        RestResponse response = getClient().request(sb.toString(), GET, parameters);
         Map<String, Object> data = response.toMap();
 		page = getIntValue(data.get("page"));
 		limit = getIntValue(data.get("limit"));

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMAccount.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMAccount.java
@@ -1,5 +1,6 @@
 package com.textmagic.sdk.resource.instance;
 
+import com.textmagic.sdk.ClientException;
 import com.textmagic.sdk.RestClient;
 import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
@@ -44,9 +45,10 @@ public class TMAccount extends Resource<RestClient> {
 	 * Get account
 	 *
 	 * @return Error state
-	 * @throws RestException exception
+	 * @throws RestException exception when TextMagic REST API returns an error
+	 * @throws ClientException when error occurs on client side
 	 */
-	public boolean get() throws RestException {
+	public boolean get() throws RestException, ClientException {
 		RestResponse response = getClient().request(getResourcePath(), GET);
         this.properties = new HashMap<String, Object>(response.toMap());
         return !response.isError();
@@ -56,9 +58,10 @@ public class TMAccount extends Resource<RestClient> {
 	 * Update account
 	 *
 	 * @return Error state
-	 * @throws RestException exception
+	 * @throws RestException exception when TextMagic REST API returns an error
+	 * @throws ClientException when error occurs on client side
 	 */
-	public boolean update() throws RestException {
+	public boolean update() throws RestException, ClientException {
 		getClient().request(getResourcePath(), PUT, buildRequestParameters(properties));
 		this.properties = new HashMap<String, Object>();
         return get();

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMAccount.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMAccount.java
@@ -5,6 +5,9 @@ import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
 import com.textmagic.sdk.resource.Resource;
 
+import static com.textmagic.sdk.RequestMethod.GET;
+import static com.textmagic.sdk.RequestMethod.PUT;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -44,7 +47,7 @@ public class TMAccount extends Resource<RestClient> {
 	 * @throws RestException exception
 	 */
 	public boolean get() throws RestException {
-		RestResponse response = getClient().request(getResourcePath(), "GET");
+		RestResponse response = getClient().request(getResourcePath(), GET);
         this.properties = new HashMap<String, Object>(response.toMap());
         return !response.isError();
 	}
@@ -56,7 +59,7 @@ public class TMAccount extends Resource<RestClient> {
 	 * @throws RestException exception
 	 */
 	public boolean update() throws RestException {
-		getClient().request(getResourcePath(), "PUT", buildRequestParameters(properties));
+		getClient().request(getResourcePath(), PUT, buildRequestParameters(properties));
 		this.properties = new HashMap<String, Object>();
         return get();
 	}    

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMContact.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMContact.java
@@ -7,6 +7,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -158,8 +161,7 @@ public class TMContact extends InstanceResource<RestClient> {
 		for (Integer id : lists) {
 			param.add(Integer.toString(id));
 		}
-    	
-    	setProperty("lists", String.join(",", param));
+    	setProperty("lists", StringUtils.join(param, ","));
     }
 	
     /**

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMCustomField.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMCustomField.java
@@ -5,6 +5,8 @@ import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
 import com.textmagic.sdk.resource.InstanceResource;
 
+import static com.textmagic.sdk.RequestMethod.PUT;
+
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Map;
@@ -61,7 +63,7 @@ public class TMCustomField extends InstanceResource<RestClient> {
             clearParameters();
             parameters.put("contactId", Integer.toString(contactId));
             parameters.put("value", value);
-            RestResponse response = getClient().request(getResourcePath() + '/' + getProperty("id") + "/update", "PUT", parameters);
+            RestResponse response = getClient().request(getResourcePath() + '/' + getProperty("id") + "/update", PUT, parameters);
             clearParameters();
             return !response.isError();
         } else {

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMList.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMList.java
@@ -5,6 +5,9 @@ import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
 import com.textmagic.sdk.resource.InstanceResource;
 
+import static com.textmagic.sdk.RequestMethod.DELETE;
+import static com.textmagic.sdk.RequestMethod.PUT;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
@@ -145,7 +148,7 @@ public class TMList extends InstanceResource<RestClient> {
             	param.add(Integer.toString(id));
             }
             parameters.put("contacts", StringUtils.join(param, ","));
-            RestResponse response = getClient().request(getResourcePath() + '/' + getProperty("id") + "/contacts", "PUT", parameters);
+            RestResponse response = getClient().request(getResourcePath() + '/' + getProperty("id") + "/contacts", PUT, parameters);
             clearParameters();
             return !response.isError();
         } else {
@@ -168,7 +171,7 @@ public class TMList extends InstanceResource<RestClient> {
             	param.add(Integer.toString(id));
             }
             parameters.put("contacts", StringUtils.join(param, ","));
-            RestResponse response = getClient().request(getResourcePath() + '/' + getProperty("id") + "/contacts", "DELETE", parameters);
+            RestResponse response = getClient().request(getResourcePath() + '/' + getProperty("id") + "/contacts", DELETE, parameters);
             clearParameters();
             return !response.isError();
         } else {

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMList.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMList.java
@@ -8,6 +8,9 @@ import com.textmagic.sdk.resource.InstanceResource;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -141,7 +144,7 @@ public class TMList extends InstanceResource<RestClient> {
             for (Integer id : contacts) {
             	param.add(Integer.toString(id));
             }
-            parameters.put("contacts", String.join(",", param));
+            parameters.put("contacts", StringUtils.join(param, ","));
             RestResponse response = getClient().request(getResourcePath() + '/' + getProperty("id") + "/contacts", "PUT", parameters);
             clearParameters();
             return !response.isError();
@@ -164,7 +167,7 @@ public class TMList extends InstanceResource<RestClient> {
             for (Integer id : contacts) {
             	param.add(Integer.toString(id));
             }
-            parameters.put("contacts", String.join(",", param));
+            parameters.put("contacts", StringUtils.join(param, ","));
             RestResponse response = getClient().request(getResourcePath() + '/' + getProperty("id") + "/contacts", "DELETE", parameters);
             clearParameters();
             return !response.isError();

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMMessagingList.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMMessagingList.java
@@ -5,6 +5,8 @@ import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
 import com.textmagic.sdk.resource.Resource;
 
+import static com.textmagic.sdk.RequestMethod.GET;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -50,7 +52,7 @@ public class TMMessagingList<T extends Resource, C extends RestClient> extends R
 	public Iterator<TMMessaging> iterator() throws RestException {
     	List<TMMessaging> data = new ArrayList<TMMessaging>();
 
-        RestResponse response = getClient().request(getResourcePath(), "GET", parameters);
+        RestResponse response = getClient().request(getResourcePath(), GET, parameters);
         List<Object> items = response.toList();
         
         for (Object item : items) {

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMNewMessage.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMNewMessage.java
@@ -1,5 +1,6 @@
 package com.textmagic.sdk.resource.instance;
 
+import com.textmagic.sdk.ClientException;
 import com.textmagic.sdk.RestClient;
 import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
@@ -48,9 +49,10 @@ public class TMNewMessage extends Resource<RestClient> {
 	 * Send new message
 	 *
      * @return Error state
-	 * @throws RestException exception
+	 * @throws RestException exception when TextMagic REST API returns an error
+	 * @throws ClientException when error occurs on client side
 	 */
-	public boolean send() throws RestException {
+	public boolean send() throws RestException, ClientException {
         properties.put("dummy", false);
 		RestResponse response = getClient().request(getResourcePath(), POST, buildRequestParameters(properties));
         this.properties = new HashMap<String, Object>(response.toMap());
@@ -61,9 +63,10 @@ public class TMNewMessage extends Resource<RestClient> {
 	 * Get message price
 	 *
 	 * @return Message price
-	 * @throws RestException exception
+	 * @throws RestException exception when TextMagic REST API returns an error
+	 * @throws ClientException when error occurs on client side
 	 */
-	public Double getPrice() throws RestException {
+	public Double getPrice() throws RestException, ClientException {
         properties.put("dummy", true);
 		RestResponse response = getClient().request(getResourcePath(), POST, buildRequestParameters(properties));
 		Map<String, Object> result = new HashMap<String, Object>(response.toMap());

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMNewMessage.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMNewMessage.java
@@ -5,6 +5,8 @@ import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
 import com.textmagic.sdk.resource.Resource;
 
+import static com.textmagic.sdk.RequestMethod.POST;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -50,7 +52,7 @@ public class TMNewMessage extends Resource<RestClient> {
 	 */
 	public boolean send() throws RestException {
         properties.put("dummy", false);
-		RestResponse response = getClient().request(getResourcePath(), "POST", buildRequestParameters(properties));
+		RestResponse response = getClient().request(getResourcePath(), POST, buildRequestParameters(properties));
         this.properties = new HashMap<String, Object>(response.toMap());
         return !response.isError();
 	}
@@ -63,7 +65,7 @@ public class TMNewMessage extends Resource<RestClient> {
 	 */
 	public Double getPrice() throws RestException {
         properties.put("dummy", true);
-		RestResponse response = getClient().request(getResourcePath(), "POST", buildRequestParameters(properties));
+		RestResponse response = getClient().request(getResourcePath(), POST, buildRequestParameters(properties));
 		Map<String, Object> result = new HashMap<String, Object>(response.toMap());
 		return (Double) result.get("total");
 	}

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMNewMessage.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMNewMessage.java
@@ -7,6 +7,7 @@ import com.textmagic.sdk.RestResponse;
 import com.textmagic.sdk.resource.Resource;
 
 import static com.textmagic.sdk.RequestMethod.POST;
+import static com.textmagic.sdk.RequestMethod.GET;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,6 +46,10 @@ public class TMNewMessage extends Resource<RestClient> {
         return "messages";
     }
 
+    protected String getPriceResourcePath() {
+        return "messages/price";
+    }
+
 	/**
 	 * Send new message
 	 *
@@ -66,9 +71,14 @@ public class TMNewMessage extends Resource<RestClient> {
 	 * @throws ClientException when error occurs on client side
 	 */
 	public Double getPrice() throws RestException, ClientException {
-		RestResponse response = getClient().request(getResourcePath(), POST, buildRequestParameters(properties));
+		RestResponse response = getClient().request(getPriceResourcePath(), GET, buildRequestParameters(properties));
 		Map<String, Object> result = new HashMap<String, Object>(response.toMap());
-		return (Double) result.get("total");
+		// Return correct type even if object is unmarshalled to Integer
+		Object total = result.get("total");
+		if (total instanceof Integer) {
+			return ((Integer) total).doubleValue();
+		}
+		return (Double) total;
 	}
 	
 	/**
@@ -134,7 +144,7 @@ public class TMNewMessage extends Resource<RestClient> {
      */
     public void setSendingTime(Date sendingTime) {
         long timestamp = (sendingTime.getTime() / 1000);
-    	setProperty("sendingTime", timestamp);
+        setProperty("sendingTime", String.valueOf(timestamp));
     }
     
     /**

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMNewMessage.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMNewMessage.java
@@ -13,6 +13,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
+
 public class TMNewMessage extends Resource<RestClient> {
 
     /**
@@ -143,7 +145,7 @@ public class TMNewMessage extends Resource<RestClient> {
 			param.add(Integer.toString(id));
 		}
     	
-    	setProperty("contacts", String.join(",", param));
+    	setProperty("contacts", StringUtils.join(param, ","));
     }
     
     /**
@@ -157,7 +159,7 @@ public class TMNewMessage extends Resource<RestClient> {
 			param.add(Integer.toString(id));
 		}
     	
-    	setProperty("lists", String.join(",", param));
+    	setProperty("lists", StringUtils.join(param, ","));
     }
     
     /**
@@ -166,7 +168,7 @@ public class TMNewMessage extends Resource<RestClient> {
      * @param phones Phones
      */
     public void setPhones(final List<String> phones) {
-        setProperty("phones", String.join(",", phones));
+        setProperty("phones", StringUtils.join(phones, ","));
     }
     
     /**

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMNewMessage.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMNewMessage.java
@@ -35,7 +35,7 @@ public class TMNewMessage extends Resource<RestClient> {
         this.properties = new HashMap<String, Object>();
         this.requestFields = new HashSet<String>(
         	Arrays.asList(
-        		new String[] {"text", "templateId", "sendingTime", "contacts", "lists", "phones", "cutExtra", "partsCount", "referenceId", "from", "rrule", "dummy"}
+        		new String[] {"text", "templateId", "sendingTime", "contacts", "lists", "phones", "cutExtra", "partsCount", "referenceId", "from", "rrule"}
         	)
         );
     }
@@ -53,7 +53,6 @@ public class TMNewMessage extends Resource<RestClient> {
 	 * @throws ClientException when error occurs on client side
 	 */
 	public boolean send() throws RestException, ClientException {
-        properties.put("dummy", false);
 		RestResponse response = getClient().request(getResourcePath(), POST, buildRequestParameters(properties));
         this.properties = new HashMap<String, Object>(response.toMap());
         return !response.isError();
@@ -67,7 +66,6 @@ public class TMNewMessage extends Resource<RestClient> {
 	 * @throws ClientException when error occurs on client side
 	 */
 	public Double getPrice() throws RestException, ClientException {
-        properties.put("dummy", true);
 		RestResponse response = getClient().request(getResourcePath(), POST, buildRequestParameters(properties));
 		Map<String, Object> result = new HashMap<String, Object>(response.toMap());
 		return (Double) result.get("total");

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMNumber.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMNumber.java
@@ -1,5 +1,6 @@
 package com.textmagic.sdk.resource.instance;
 
+import com.textmagic.sdk.ClientException;
 import com.textmagic.sdk.RestClient;
 import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
@@ -73,10 +74,11 @@ public class TMNumber extends InstanceResource<RestClient> {
      * @param country Country
      * @param prefix Prefix
      * @return Available numbers
-     * @throws RestException exception
+     * @throws RestException exception when TextMagic REST API returns an error
+	 * @throws ClientException when error occurs on client side
      */
     @SuppressWarnings("unchecked")
-	public List<String> getAvailableNumbers(String country, String prefix) throws RestException {
+	public List<String> getAvailableNumbers(String country, String prefix) throws RestException, ClientException {
         Map<String, String> params = new HashMap<String, String>();
         params.put("country", country);
         params.put("prefix", prefix);

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMNumber.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMNumber.java
@@ -8,6 +8,10 @@ import com.textmagic.sdk.resource.InstanceResource;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.HashMap;
+
+import static com.textmagic.sdk.RequestMethod.GET;
+import static com.textmagic.sdk.RequestMethod.POST;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +57,7 @@ public class TMNumber extends InstanceResource<RestClient> {
     @Override
 	public boolean createOrUpdate() throws RestException {
 		if (getProperty("id") == null) {
-            RestResponse response = getClient().request(getResourcePath(), "POST", buildRequestParameters(properties));
+            RestResponse response = getClient().request(getResourcePath(), POST, buildRequestParameters(properties));
             Map<String, Object> properties = response.toMap();
             Integer id = (Integer) properties.get("id");
             clearProperties();
@@ -76,7 +80,7 @@ public class TMNumber extends InstanceResource<RestClient> {
         Map<String, String> params = new HashMap<String, String>();
         params.put("country", country);
         params.put("prefix", prefix);
-        RestResponse response = getClient().request(getResourcePath() + "/available", "GET", params);
+        RestResponse response = getClient().request(getResourcePath() + "/available", GET, params);
         Map<String, Object> available = new HashMap<String, Object>(response.toMap());
 
     	return (List<String>) available.get("numbers");

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMSenderId.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMSenderId.java
@@ -6,6 +6,9 @@ import com.textmagic.sdk.RestResponse;
 import com.textmagic.sdk.resource.InstanceResource;
 
 import java.util.HashSet;
+
+import static com.textmagic.sdk.RequestMethod.POST;
+
 import java.util.Arrays;
 import java.util.Map;
 
@@ -50,7 +53,7 @@ public class TMSenderId extends InstanceResource<RestClient> {
     @Override
 	public boolean createOrUpdate() throws RestException {
 		if (getProperty("id") == null) {
-            RestResponse response = getClient().request(getResourcePath(), "POST", buildRequestParameters(properties));
+            RestResponse response = getClient().request(getResourcePath(), POST, buildRequestParameters(properties));
             Map<String, Object> properties = response.toMap();
             Integer id = (Integer) properties.get("id");
             clearProperties();

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMSourceList.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMSourceList.java
@@ -5,6 +5,8 @@ import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
 import com.textmagic.sdk.resource.Resource;
 
+import static com.textmagic.sdk.RequestMethod.GET;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +47,7 @@ public class TMSourceList<T extends Resource, C extends RestClient> extends Reso
      */
     @SuppressWarnings("unchecked")
 	public List<String> getDedicatedNumbers() throws RestException {
-        RestResponse response = getClient().request(getResourcePath(), "GET", parameters);
+        RestResponse response = getClient().request(getResourcePath(), GET, parameters);
         Map<String, Object> sources = new HashMap<String, Object>(response.toMap());
 
     	return (List<String>) sources.get("dedicated");
@@ -59,7 +61,7 @@ public class TMSourceList<T extends Resource, C extends RestClient> extends Reso
      */
     @SuppressWarnings("unchecked")
 	public List<String> getUserPhones() throws RestException {
-        RestResponse response = getClient().request(getResourcePath(), "GET", parameters);
+        RestResponse response = getClient().request(getResourcePath(), GET, parameters);
         Map<String, Object> sources = new HashMap<String, Object>(response.toMap());
 
     	return (List<String>) sources.get("user");
@@ -73,7 +75,7 @@ public class TMSourceList<T extends Resource, C extends RestClient> extends Reso
      */
     @SuppressWarnings("unchecked")
 	public List<String> getSharedNumbers() throws RestException {
-        RestResponse response = getClient().request(getResourcePath(), "GET", parameters);
+        RestResponse response = getClient().request(getResourcePath(), GET, parameters);
         Map<String, Object> sources = new HashMap<String, Object>(response.toMap());
 
     	return (List<String>) sources.get("shared");
@@ -87,7 +89,7 @@ public class TMSourceList<T extends Resource, C extends RestClient> extends Reso
      */
     @SuppressWarnings("unchecked")
 	public List<String> getSenderIds() throws RestException {
-        RestResponse response = getClient().request(getResourcePath(), "GET", parameters);
+        RestResponse response = getClient().request(getResourcePath(), GET, parameters);
         Map<String, Object> sources = new HashMap<String, Object>(response.toMap());
 
     	return (List<String>) sources.get("senderIds");

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMSourceList.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMSourceList.java
@@ -1,5 +1,6 @@
 package com.textmagic.sdk.resource.instance;
 
+import com.textmagic.sdk.ClientException;
 import com.textmagic.sdk.RestClient;
 import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
@@ -43,10 +44,11 @@ public class TMSourceList<T extends Resource, C extends RestClient> extends Reso
      * Retrieve dedicated numbers
      *
      * @return Dedicated numbers
-     * @throws RestException exception
+     * @throws RestException exception when TextMagic REST API returns an error
+	 * @throws ClientException when error occurs on client side
      */
     @SuppressWarnings("unchecked")
-	public List<String> getDedicatedNumbers() throws RestException {
+	public List<String> getDedicatedNumbers() throws RestException, ClientException {
         RestResponse response = getClient().request(getResourcePath(), GET, parameters);
         Map<String, Object> sources = new HashMap<String, Object>(response.toMap());
 
@@ -57,10 +59,11 @@ public class TMSourceList<T extends Resource, C extends RestClient> extends Reso
      * Retrieve user phones
      *
      * @return User phones
-     * @throws RestException exception
+     * @throws RestException exception when TextMagic REST API returns an error
+	 * @throws ClientException when error occurs on client side
      */
     @SuppressWarnings("unchecked")
-	public List<String> getUserPhones() throws RestException {
+	public List<String> getUserPhones() throws RestException, ClientException {
         RestResponse response = getClient().request(getResourcePath(), GET, parameters);
         Map<String, Object> sources = new HashMap<String, Object>(response.toMap());
 
@@ -71,10 +74,11 @@ public class TMSourceList<T extends Resource, C extends RestClient> extends Reso
      * Retrieve shared numbers
      *
      * @return Shared numbers
-     * @throws RestException exception
+     * @throws RestException exception when TextMagic REST API returns an error
+	 * @throws ClientException when error occurs on client side
      */
     @SuppressWarnings("unchecked")
-	public List<String> getSharedNumbers() throws RestException {
+	public List<String> getSharedNumbers() throws RestException, ClientException {
         RestResponse response = getClient().request(getResourcePath(), GET, parameters);
         Map<String, Object> sources = new HashMap<String, Object>(response.toMap());
 
@@ -85,10 +89,11 @@ public class TMSourceList<T extends Resource, C extends RestClient> extends Reso
      * Retrieve numbers
      *
      * @return numbers
-     * @throws RestException exception
+     * @throws RestException exception when TextMagic REST API returns an error
+	 * @throws ClientException when error occurs on client side
      */
     @SuppressWarnings("unchecked")
-	public List<String> getSenderIds() throws RestException {
+	public List<String> getSenderIds() throws RestException, ClientException {
         RestResponse response = getClient().request(getResourcePath(), GET, parameters);
         Map<String, Object> sources = new HashMap<String, Object>(response.toMap());
 

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMStatementList.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMStatementList.java
@@ -5,6 +5,8 @@ import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
 import com.textmagic.sdk.resource.ListResource;
 
+import static com.textmagic.sdk.RequestMethod.GET;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +38,7 @@ public class TMStatementList extends ListResource<TMStatement, RestClient> {
 		parameters.put("page", Integer.toString(this.page));
         parameters.put("limit", Integer.toString(this.limit));
 
-        RestResponse response = getClient().request(getResourcePath(), "GET", parameters);
+        RestResponse response = getClient().request(getResourcePath(), GET, parameters);
         Map<String, Object> data = response.toMap();
 		page = getIntValue(data.get("page"));
 		limit = getIntValue(data.get("limit"));

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMStatementList.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMStatementList.java
@@ -1,5 +1,6 @@
 package com.textmagic.sdk.resource.instance;
 
+import com.textmagic.sdk.ClientException;
 import com.textmagic.sdk.RestClient;
 import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
@@ -34,7 +35,7 @@ public class TMStatementList extends ListResource<TMStatement, RestClient> {
 
     @Override
     @SuppressWarnings("unchecked")
-	protected void getListContent() throws RestException {
+	protected void getListContent() throws RestException, ClientException {
 		parameters.put("page", Integer.toString(this.page));
         parameters.put("limit", Integer.toString(this.limit));
 

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMSubaccount.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMSubaccount.java
@@ -5,6 +5,11 @@ import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
 
 import java.util.HashSet;
+
+import static com.textmagic.sdk.RequestMethod.DELETE;
+import static com.textmagic.sdk.RequestMethod.GET;
+import static com.textmagic.sdk.RequestMethod.POST;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -50,7 +55,7 @@ public class TMSubaccount extends TMUser {
     @Override
     public boolean get(Integer id) throws RestException {
 		if (properties.size() == 0) {
-            RestResponse response = getClient().request(getResourcePath() + '/' + id, "GET");
+            RestResponse response = getClient().request(getResourcePath() + '/' + id, GET);
             this.properties = new HashMap<String, Object>(response.toMap());
             return !response.isError();
 		} else {
@@ -61,7 +66,7 @@ public class TMSubaccount extends TMUser {
     @Override
 	public boolean createOrUpdate() throws RestException {
 		if (getProperty("id") == null) {
-			RestResponse response = getClient().request(getResourcePath(), "POST", buildRequestParameters(properties));
+			RestResponse response = getClient().request(getResourcePath(), POST, buildRequestParameters(properties));
             clearProperties();
             return !response.isError();
 		} else {
@@ -74,7 +79,7 @@ public class TMSubaccount extends TMUser {
 		if (getProperty("id") == null) {
 			throw new UnsupportedOperationException("This operation is unsupported for non existent objects");
 		} else {
-			RestResponse response = getClient().request(getResourcePath() + '/' + getProperty("id"), "DELETE");
+			RestResponse response = getClient().request(getResourcePath() + '/' + getProperty("id"), DELETE);
             clearProperties();
             return !response.isError();
 		}

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMSubaccount.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMSubaccount.java
@@ -1,5 +1,6 @@
 package com.textmagic.sdk.resource.instance;
 
+import com.textmagic.sdk.ClientException;
 import com.textmagic.sdk.RestClient;
 import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
@@ -53,7 +54,7 @@ public class TMSubaccount extends TMUser {
     }
     
     @Override
-    public boolean get(Integer id) throws RestException {
+    public boolean get(Integer id) throws RestException, ClientException {
 		if (properties.size() == 0) {
             RestResponse response = getClient().request(getResourcePath() + '/' + id, GET);
             this.properties = new HashMap<String, Object>(response.toMap());
@@ -64,7 +65,7 @@ public class TMSubaccount extends TMUser {
 	}
     
     @Override
-	public boolean createOrUpdate() throws RestException {
+	public boolean createOrUpdate() throws RestException, ClientException {
 		if (getProperty("id") == null) {
 			RestResponse response = getClient().request(getResourcePath(), POST, buildRequestParameters(properties));
             clearProperties();
@@ -75,7 +76,7 @@ public class TMSubaccount extends TMUser {
 	}
     
 	@Override
-	public boolean delete() throws RestException {
+	public boolean delete() throws RestException, ClientException {
 		if (getProperty("id") == null) {
 			throw new UnsupportedOperationException("This operation is unsupported for non existent objects");
 		} else {

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMSubaccount.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMSubaccount.java
@@ -96,7 +96,10 @@ public class TMSubaccount extends TMUser {
     }
     
     /**
-     * Set role
+     * Set role:<ul>
+     * <li>A for administrator
+     * <li>U for regular user
+     * </ul>
      *
      * @param role Role
      */

--- a/src/main/java/com/textmagic/sdk/resource/instance/TMUnsubscriber.java
+++ b/src/main/java/com/textmagic/sdk/resource/instance/TMUnsubscriber.java
@@ -5,6 +5,8 @@ import com.textmagic.sdk.RestException;
 import com.textmagic.sdk.RestResponse;
 import com.textmagic.sdk.resource.InstanceResource;
 
+import static com.textmagic.sdk.RequestMethod.POST;
+
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Map;
@@ -51,7 +53,7 @@ public class TMUnsubscriber extends InstanceResource<RestClient> {
     @Override
 	public boolean createOrUpdate() throws RestException {
 		if (getProperty("id") == null) {
-            RestResponse response = getClient().request(getResourcePath(), "POST", buildRequestParameters(properties));
+            RestResponse response = getClient().request(getResourcePath(), POST, buildRequestParameters(properties));
             Map<String, Object> properties = response.toMap();
             Integer id = (Integer) properties.get("id");
             clearProperties();

--- a/src/test/java/com/textmagic/sdk/BasicTest.java
+++ b/src/test/java/com/textmagic/sdk/BasicTest.java
@@ -54,7 +54,7 @@ public class BasicTest {
 	final String username = "<USERNAME>";
 	final String token = "<APIV2_TOKEN>";
 
-	protected RestClient client = spy(new RestClient(username, token));
+	protected RestClient client = spy(new RestClient(username, token, RestClient.TESTING_URI));
 
 	
 	@Before

--- a/src/test/java/com/textmagic/sdk/BasicTest.java
+++ b/src/test/java/com/textmagic/sdk/BasicTest.java
@@ -62,7 +62,7 @@ public class BasicTest {
 		MockitoAnnotations.initMocks(this);
 	}
 
-	protected void setMockResponse(final String method, final String url, final Map<String, String> params, String resourceName, Integer status) throws Exception {
+	protected void setMockResponse(final RequestMethod method, final String url, final Map<String, String> params, String resourceName, Integer status) throws Exception {
 		String response = null;
 		if (resourceName != null) {
 			response = IOUtils.toString(BasicTest.class.getResourceAsStream(resourceName), "UTF-8");

--- a/src/test/java/com/textmagic/sdk/BasicTest.java
+++ b/src/test/java/com/textmagic/sdk/BasicTest.java
@@ -54,7 +54,7 @@ public class BasicTest {
 	final String username = "<USERNAME>";
 	final String token = "<APIV2_TOKEN>";
 
-	protected RestClient client = spy(new RestClient(username, token, RestClient.TESTING_URI));
+	protected RestClient client = spy(new RestClient(username, token));
 
 	
 	@Before

--- a/src/test/java/com/textmagic/sdk/RestClientTest.java
+++ b/src/test/java/com/textmagic/sdk/RestClientTest.java
@@ -17,6 +17,19 @@ import org.junit.Test;
 import com.textmagic.sdk.resource.instance.*;
 
 public class RestClientTest extends BasicTest {
+
+	@Test
+	public void testEndpointSelectionTest() {
+		client = new RestClient("user", "token", RestClient.TESTING_URI);
+		assertTrue(client.getApiUri().startsWith("https://api.textmagictesting.com"));
+	}
+
+	@Test
+	public void testEndpointSelectionProduction() {
+		client = new RestClient("user", "token", RestClient.PRODUCTION_URI);
+		assertTrue(client.getApiUri().startsWith("https://api.textmagic.com"));
+	}
+
 	@Test
     public void testBulk() throws Exception {
 		Map<String, String> parameters = new HashMap<String, String>();

--- a/src/test/java/com/textmagic/sdk/RestClientTest.java
+++ b/src/test/java/com/textmagic/sdk/RestClientTest.java
@@ -1,5 +1,9 @@
 package com.textmagic.sdk;
 
+import static com.textmagic.sdk.RequestMethod.DELETE;
+import static com.textmagic.sdk.RequestMethod.GET;
+import static com.textmagic.sdk.RequestMethod.POST;
+import static com.textmagic.sdk.RequestMethod.PUT;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
@@ -16,7 +20,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testBulk() throws Exception {
 		Map<String, String> parameters = new HashMap<String, String>();
-		setMockResponse("GET", "bulks/1", parameters, "bulkRetrieve.json", 200);
+		setMockResponse(GET, "bulks/1", parameters, "bulkRetrieve.json", 200);
         TMBulk b = client.getResource(TMBulk.class);
         try {
             b.get(1);
@@ -37,7 +41,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "bulks", parameters, "bulkList.json", 200);
+		setMockResponse(GET, "bulks", parameters, "bulkList.json", 200);
 		TMBulkList bl = client.getResource(TMBulkList.class);		
 		Iterator<TMBulk> iterator = bl.iterator();
 		assertTrue(iterator.hasNext());
@@ -56,8 +60,8 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "chats", parameters, "chatList.json", 200);
-		setMockResponse("GET", "chats/1234567890", parameters, "chatMessageList.json", 200);
+		setMockResponse(GET, "chats", parameters, "chatList.json", 200);
+		setMockResponse(GET, "chats/1234567890", parameters, "chatMessageList.json", 200);
 		TMChatList cl = client.getResource(TMChatList.class);
 		Iterator<TMChat> iterator = cl.iterator();
 		assertTrue(iterator.hasNext());
@@ -81,7 +85,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "lists", parameters, "listList.json", 200);
+		setMockResponse(GET, "lists", parameters, "listList.json", 200);
 		TMListList ll = client.getResource(TMListList.class);		
 		Iterator<TMList> iterator = ll.iterator();
 		assertTrue(iterator.hasNext());
@@ -100,7 +104,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("ids", "1");
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "lists/search", parameters, "listList.json", 200);
+		setMockResponse(GET, "lists/search", parameters, "listList.json", 200);
 		TMListList ll = client.getResource(TMListList.class, parameters);
 		Iterator<TMList> iterator = ll.iterator();
 		assertTrue(iterator.hasNext());
@@ -118,9 +122,9 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parametersPost = new HashMap<String, String>();
 		parametersPost.put("name", "TEST");
 		parametersPost.put("shared", "1");
-		setMockResponse("POST", "lists", parametersPost, "listCreateUpdate.json", 201);
+		setMockResponse(POST, "lists", parametersPost, "listCreateUpdate.json", 201);
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "lists/1", parametersGet, "listRetrieve.json", 200);
+		setMockResponse(GET, "lists/1", parametersGet, "listRetrieve.json", 200);
 		TMList l = client.getResource(TMList.class);
 		l.setName("TEST");
 		l.setShared(true);
@@ -140,7 +144,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testUpdateList() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "lists/1", parametersGet, "listRetrieve.json", 200);
+		setMockResponse(GET, "lists/1", parametersGet, "listRetrieve.json", 200);
 		TMList l = client.getResource(TMList.class);
 		try {
 		    l.get(1);
@@ -156,8 +160,8 @@ public class RestClientTest extends BasicTest {
         Map<String, String> parametersPut = new HashMap<String, String>();
         parametersPut.put("name", "TEST");
         parametersPut.put("shared", "0");
-        setMockResponse("PUT", "lists/1", parametersPut, "listCreateUpdate.json", 201);
-		setMockResponse("GET", "lists/1", parametersGet, "listRetrieveUpdated.json", 200);
+        setMockResponse(PUT, "lists/1", parametersPut, "listCreateUpdate.json", 201);
+		setMockResponse(GET, "lists/1", parametersGet, "listRetrieveUpdated.json", 200);
         l.setShared(false);
         try {
 		    l.createOrUpdate();
@@ -181,9 +185,9 @@ public class RestClientTest extends BasicTest {
 		parametersPost.put("email", "TEST");
 		parametersPost.put("companyName", "TEST");
 		parametersPost.put("lists", "1");
-		setMockResponse("POST", "contacts", parametersPost, "contactCreateUpdate.json", 201);
+		setMockResponse(POST, "contacts", parametersPost, "contactCreateUpdate.json", 201);
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "contacts/1", parametersGet, "contactRetrieve.json", 200);
+		setMockResponse(GET, "contacts/1", parametersGet, "contactRetrieve.json", 200);
 		TMContact c = client.getResource(TMContact.class);
 		c.setFirstName("TEST");
 		c.setLastName("TEST");
@@ -208,7 +212,7 @@ public class RestClientTest extends BasicTest {
 	@Test
 	public void testUpdateListContacts() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "lists/1", parametersGet, "listRetrieve.json", 200);
+		setMockResponse(GET, "lists/1", parametersGet, "listRetrieve.json", 200);
 		TMList l = client.getResource(TMList.class);
 		try {
 		    l.get(1);
@@ -218,14 +222,14 @@ public class RestClientTest extends BasicTest {
 		}
 		Map<String, String> parametersPut = new HashMap<String, String>();
 		parametersPut.put("contacts", "1");
-		setMockResponse("PUT", "lists/1/contacts", parametersPut, "listCreateUpdate.json", 201);
+		setMockResponse(PUT, "lists/1/contacts", parametersPut, "listCreateUpdate.json", 201);
 		assertTrue(l.addContactsToList(Arrays.asList(new Integer[] {1})));
 	}
 	
 	@Test
 	public void testDeleteListContacts() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "lists/1", parametersGet, "listRetrieve.json", 200);
+		setMockResponse(GET, "lists/1", parametersGet, "listRetrieve.json", 200);
 		TMList l = client.getResource(TMList.class);
 		try {
 		    l.get(1);
@@ -235,14 +239,14 @@ public class RestClientTest extends BasicTest {
 		}
 		Map<String, String> parametersDelete = new HashMap<String, String>();
 		parametersDelete.put("contacts", "1");
-		setMockResponse("DELETE", "lists/1/contacts", parametersDelete, null, 201);
+		setMockResponse(DELETE, "lists/1/contacts", parametersDelete, null, 201);
 		assertTrue(l.removeContactsFromList(Arrays.asList(new Integer[] {1})));
 	}
 	
 	@Test
 	public void retrieveListContacts() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "lists/1", parametersGet, "listRetrieve.json", 200);
+		setMockResponse(GET, "lists/1", parametersGet, "listRetrieve.json", 200);
 		TMList l = client.getResource(TMList.class);
 		try {
 		    l.get(1);
@@ -253,7 +257,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parametersList = new HashMap<String, String>();
 		parametersList.put("page", "1");
 		parametersList.put("limit", "10");
-		setMockResponse("GET", "lists/1/contacts", parametersList, "contactList.json", 200);
+		setMockResponse(GET, "lists/1/contacts", parametersList, "contactList.json", 200);
 		Iterator<TMContact> iterator = l.getContactsIterator();
 		assertTrue(iterator.hasNext());
 		TMContact c = iterator.next();
@@ -271,7 +275,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "contacts", parameters, "contactList.json", 200);
+		setMockResponse(GET, "contacts", parameters, "contactList.json", 200);
 		TMContactList cl = client.getResource(TMContactList.class, parameters);
 		Iterator<TMContact> iterator = cl.iterator();
 		assertTrue(iterator.hasNext());
@@ -292,7 +296,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("listId", "1");
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "contacts/search", parameters, "contactList.json", 200);
+		setMockResponse(GET, "contacts/search", parameters, "contactList.json", 200);
 		TMContactList cl = client.getResource(TMContactList.class, parameters);
 		Iterator<TMContact> iterator = cl.iterator();
 		assertTrue(iterator.hasNext());
@@ -310,7 +314,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testUpdateContact() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "contacts/1", parametersGet, "contactRetrieve.json", 200);
+		setMockResponse(GET, "contacts/1", parametersGet, "contactRetrieve.json", 200);
 		TMContact c = client.getResource(TMContact.class);
 		try {
 		    c.get(1);
@@ -331,8 +335,8 @@ public class RestClientTest extends BasicTest {
         parametersPut.put("email", "TEST1");
         parametersPut.put("companyName", "TEST1");
         parametersPut.put("lists", "1");
-        setMockResponse("PUT", "contacts/1", parametersPut, "contactCreateUpdate.json", 201);
-		setMockResponse("GET", "contacts/1", parametersGet, "contactRetrieveUpdated.json", 200);
+        setMockResponse(PUT, "contacts/1", parametersPut, "contactCreateUpdate.json", 201);
+		setMockResponse(GET, "contacts/1", parametersGet, "contactRetrieveUpdated.json", 200);
 		c.setFirstName("TEST1");
 		c.setLastName("TEST1");
 		c.setPhone("1234567890");
@@ -358,7 +362,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "customfields", parameters, "customfieldList.json", 200);
+		setMockResponse(GET, "customfields", parameters, "customfieldList.json", 200);
 		TMCustomFieldList cfl = client.getResource(TMCustomFieldList.class);
 		Iterator<TMCustomField> iterator = cfl.iterator();
 		assertTrue(iterator.hasNext());
@@ -372,9 +376,9 @@ public class RestClientTest extends BasicTest {
     public void testCreateCustomField() throws Exception {
 		Map<String, String> parametersPost = new HashMap<String, String>();
 		parametersPost.put("name", "TEST");
-		setMockResponse("POST", "customfields", parametersPost, "customfieldCreateUpdate.json", 201);
+		setMockResponse(POST, "customfields", parametersPost, "customfieldCreateUpdate.json", 201);
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "customfields/1", parametersGet, "customfieldRetrieve.json", 200);
+		setMockResponse(GET, "customfields/1", parametersGet, "customfieldRetrieve.json", 200);
 		TMCustomField c = client.getResource(TMCustomField.class);
 		c.setName("TEST");
 		try {
@@ -390,7 +394,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testUpdateCustomField() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "customfields/1", parametersGet, "customfieldRetrieve.json", 200);
+		setMockResponse(GET, "customfields/1", parametersGet, "customfieldRetrieve.json", 200);
 		TMCustomField c = client.getResource(TMCustomField.class);
 		try {
 		    c.get(1);
@@ -402,8 +406,8 @@ public class RestClientTest extends BasicTest {
 		assertEquals("TEST", c.getName());
         Map<String, String> parametersPut = new HashMap<String, String>();
         parametersPut.put("name", "TEST1");
-        setMockResponse("PUT", "customfields/1", parametersPut, "customfieldCreateUpdate.json", 201);
-		setMockResponse("GET", "customfields/1", parametersGet, "customfieldRetrieveUpdated.json", 200);
+        setMockResponse(PUT, "customfields/1", parametersPut, "customfieldCreateUpdate.json", 201);
+		setMockResponse(GET, "customfields/1", parametersGet, "customfieldRetrieveUpdated.json", 200);
         c.setName("TEST1");
         try {
 		    c.createOrUpdate();
@@ -418,7 +422,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testUpdateCustomFieldValue() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "customfields/1", parametersGet, "customfieldRetrieve.json", 200);
+		setMockResponse(GET, "customfields/1", parametersGet, "customfieldRetrieve.json", 200);
 		TMCustomField c = client.getResource(TMCustomField.class);
 		try {
 		    c.get(1);
@@ -429,14 +433,14 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parametersPut = new HashMap<String, String>();
         parametersPut.put("contactId", "1");
         parametersPut.put("value", "TEST");
-        setMockResponse("PUT", "customfields/1/update", parametersPut, "customfieldCreateUpdate.json", 201);
+        setMockResponse(PUT, "customfields/1/update", parametersPut, "customfieldCreateUpdate.json", 201);
 		assertTrue(c.updateContactValue(1, "TEST"));
 	}
 	
 	@Test
     public void testDeleteCustomField() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "customfields/1", parametersGet, "customfieldRetrieve.json", 200);
+		setMockResponse(GET, "customfields/1", parametersGet, "customfieldRetrieve.json", 200);
 		TMCustomField c = client.getResource(TMCustomField.class);
 		try {
 		    c.get(1);
@@ -445,7 +449,7 @@ public class RestClientTest extends BasicTest {
 		    throw new RuntimeException(e);
 		}
 		Map<String, String> parametersDelete = new HashMap<String, String>();
-		setMockResponse("DELETE", "customfields/1", parametersDelete, null, 201);
+		setMockResponse(DELETE, "customfields/1", parametersDelete, null, 201);
 		try {
 		    assertTrue(c.delete());
 		} catch (final RestException e) {
@@ -457,7 +461,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testDeleteContact() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "contacts/1", parametersGet, "contactRetrieve.json", 200);
+		setMockResponse(GET, "contacts/1", parametersGet, "contactRetrieve.json", 200);
 		TMContact c = client.getResource(TMContact.class);
 		try {
 		    c.get(1);
@@ -466,7 +470,7 @@ public class RestClientTest extends BasicTest {
 		    throw new RuntimeException(e);
 		}
 		Map<String, String> parametersDelete = new HashMap<String, String>();
-		setMockResponse("DELETE", "contacts/1", parametersDelete, null, 201);
+		setMockResponse(DELETE, "contacts/1", parametersDelete, null, 201);
 		try {
 		    assertTrue(c.delete());
 		} catch (final RestException e) {
@@ -480,7 +484,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "messages", parameters, "messageList.json", 200);
+		setMockResponse(GET, "messages", parameters, "messageList.json", 200);
 		TMMessageList ml = client.getResource(TMMessageList.class);
 		Iterator<TMMessage> iterator = ml.iterator();
 		assertTrue(iterator.hasNext());
@@ -498,7 +502,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("ids", "1");
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "messages/search", parameters, "messageList.json", 200);
+		setMockResponse(GET, "messages/search", parameters, "messageList.json", 200);
 		TMMessageList ml = client.getResource(TMMessageList.class, parameters);
 		Iterator<TMMessage> iterator = ml.iterator();
 		assertTrue(iterator.hasNext());
@@ -516,7 +520,7 @@ public class RestClientTest extends BasicTest {
 		parametersPost.put("text", "TEST");
 		parametersPost.put("phones", "1234567890");
 		parametersPost.put("dummy", "1");
-		setMockResponse("POST", "messages", parametersPost, "messagePrice.json", 201);
+		setMockResponse(POST, "messages", parametersPost, "messagePrice.json", 201);
 		TMNewMessage m = client.getResource(TMNewMessage.class);
 		m.setText("TEST");
 		m.setPhones(Arrays.asList(new String[] {"1234567890"}));
@@ -534,7 +538,7 @@ public class RestClientTest extends BasicTest {
 		parametersPost.put("text", "TEST");
 		parametersPost.put("phones", "1234567890");
 		parametersPost.put("dummy", "0");
-		setMockResponse("POST", "messages", parametersPost, "messageSend.json", 201);
+		setMockResponse(POST, "messages", parametersPost, "messageSend.json", 201);
 		TMNewMessage m = client.getResource(TMNewMessage.class);
 		m.setText("TEST");
 		m.setPhones(Arrays.asList(new String[] {"1234567890"}));
@@ -552,7 +556,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "sessions", parameters, "sessionList.json", 200);
+		setMockResponse(GET, "sessions", parameters, "sessionList.json", 200);
 		TMSessionList sl = client.getResource(TMSessionList.class);
 		Iterator<TMSession> iterator = sl.iterator();
 		assertTrue(iterator.hasNext());
@@ -568,7 +572,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testSession() throws Exception {
 		Map<String, String> parameters = new HashMap<String, String>();
-		setMockResponse("GET", "sessions/1", parameters, "sessionRetrieve.json", 200);
+		setMockResponse(GET, "sessions/1", parameters, "sessionRetrieve.json", 200);
         TMSession s = client.getResource(TMSession.class);
         try {
             s.get(1);
@@ -586,7 +590,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testMessage() throws Exception {
 		Map<String, String> parameters = new HashMap<String, String>();
-		setMockResponse("GET", "messages/1", parameters, "messageRetrieve.json", 200);
+		setMockResponse(GET, "messages/1", parameters, "messageRetrieve.json", 200);
         TMMessage m = client.getResource(TMMessage.class);
         try {
             m.get(1);
@@ -603,7 +607,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testDeleteMessage() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "messages/1", parametersGet, "messageRetrieve.json", 200);
+		setMockResponse(GET, "messages/1", parametersGet, "messageRetrieve.json", 200);
 		TMMessage m = client.getResource(TMMessage.class);
 		try {
 		    m.get(1);
@@ -612,7 +616,7 @@ public class RestClientTest extends BasicTest {
 		    throw new RuntimeException(e);
 		}
 		Map<String, String> parametersDelete = new HashMap<String, String>();
-		setMockResponse("DELETE", "messages/1", parametersDelete, null, 201);
+		setMockResponse(DELETE, "messages/1", parametersDelete, null, 201);
 		try {
 		    assertTrue(m.delete());
 		} catch (final RestException e) {
@@ -624,7 +628,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testDeleteSession() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "sessions/1", parametersGet, "sessionRetrieve.json", 200);
+		setMockResponse(GET, "sessions/1", parametersGet, "sessionRetrieve.json", 200);
 		TMSession s = client.getResource(TMSession.class);
 		try {
 		    s.get(1);
@@ -633,7 +637,7 @@ public class RestClientTest extends BasicTest {
 		    throw new RuntimeException(e);
 		}
 		Map<String, String> parametersDelete = new HashMap<String, String>();
-		setMockResponse("DELETE", "sessions/1", parametersDelete, null, 201);
+		setMockResponse(DELETE, "sessions/1", parametersDelete, null, 201);
 		try {
 		    assertTrue(s.delete());
 		} catch (final RestException e) {
@@ -647,7 +651,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "replies", parameters, "replyList.json", 200);
+		setMockResponse(GET, "replies", parameters, "replyList.json", 200);
 		TMReplyList rl = client.getResource(TMReplyList.class);
 		Iterator<TMReply> iterator = rl.iterator();
 		assertTrue(iterator.hasNext());
@@ -665,7 +669,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("ids", "1");
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "replies/search", parameters, "replyList.json", 200);
+		setMockResponse(GET, "replies/search", parameters, "replyList.json", 200);
 		TMReplyList rl = client.getResource(TMReplyList.class, parameters);
 		Iterator<TMReply> iterator = rl.iterator();
 		assertTrue(iterator.hasNext());
@@ -680,7 +684,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testReply() throws Exception {
 		Map<String, String> parameters = new HashMap<String, String>();
-		setMockResponse("GET", "replies/1", parameters, "replyRetrieve.json", 200);
+		setMockResponse(GET, "replies/1", parameters, "replyRetrieve.json", 200);
         TMReply r = client.getResource(TMReply.class);
         try {
             r.get(1);
@@ -697,7 +701,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testDeleteReply() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "replies/1", parametersGet, "replyRetrieve.json", 200);
+		setMockResponse(GET, "replies/1", parametersGet, "replyRetrieve.json", 200);
 		TMReply r = client.getResource(TMReply.class);
 		try {
 		    r.get(1);
@@ -706,7 +710,7 @@ public class RestClientTest extends BasicTest {
 		    throw new RuntimeException(e);
 		}
 		Map<String, String> parametersDelete = new HashMap<String, String>();
-		setMockResponse("DELETE", "replies/1", parametersDelete, null, 201);
+		setMockResponse(DELETE, "replies/1", parametersDelete, null, 201);
 		try {
 		    assertTrue(r.delete());
 		} catch (final RestException e) {
@@ -720,7 +724,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "schedules", parameters, "scheduleList.json", 200);
+		setMockResponse(GET, "schedules", parameters, "scheduleList.json", 200);
 		TMScheduleList sl = client.getResource(TMScheduleList.class);
 		Iterator<TMSchedule> iterator = sl.iterator();
 		assertTrue(iterator.hasNext());
@@ -733,7 +737,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testSchedule() throws Exception {
 		Map<String, String> parameters = new HashMap<String, String>();
-		setMockResponse("GET", "schedules/1", parameters, "scheduleRetrieve.json", 200);
+		setMockResponse(GET, "schedules/1", parameters, "scheduleRetrieve.json", 200);
         TMSchedule s = client.getResource(TMSchedule.class);
         try {
             s.get(1);
@@ -748,7 +752,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testDeleteSchedule() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "schedules/1", parametersGet, "scheduleRetrieve.json", 200);
+		setMockResponse(GET, "schedules/1", parametersGet, "scheduleRetrieve.json", 200);
 		TMSchedule s = client.getResource(TMSchedule.class);
 		try {
 		    s.get(1);
@@ -757,7 +761,7 @@ public class RestClientTest extends BasicTest {
 		    throw new RuntimeException(e);
 		}
 		Map<String, String> parametersDelete = new HashMap<String, String>();
-		setMockResponse("DELETE", "schedules/1", parametersDelete, null, 201);
+		setMockResponse(DELETE, "schedules/1", parametersDelete, null, 201);
 		try {
 		    assertTrue(s.delete());
 		} catch (final RestException e) {
@@ -771,7 +775,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "templates", parameters, "templateList.json", 200);
+		setMockResponse(GET, "templates", parameters, "templateList.json", 200);
 		TMTemplateList tl = client.getResource(TMTemplateList.class);
 		Iterator<TMTemplate> iterator = tl.iterator();
 		assertTrue(iterator.hasNext());
@@ -788,7 +792,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("ids", "1");
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "templates/search", parameters, "templateList.json", 200);
+		setMockResponse(GET, "templates/search", parameters, "templateList.json", 200);
 		TMTemplateList tl = client.getResource(TMTemplateList.class, parameters);
 		Iterator<TMTemplate> iterator = tl.iterator();
 		assertTrue(iterator.hasNext());
@@ -804,9 +808,9 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parametersPost = new HashMap<String, String>();
 		parametersPost.put("name", "TEST");
 		parametersPost.put("content", "TEST");
-		setMockResponse("POST", "templates", parametersPost, "templateCreateUpdate.json", 201);
+		setMockResponse(POST, "templates", parametersPost, "templateCreateUpdate.json", 201);
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "templates/1", parametersGet, "templateRetrieve.json", 200);
+		setMockResponse(GET, "templates/1", parametersGet, "templateRetrieve.json", 200);
 		TMTemplate t = client.getResource(TMTemplate.class);
 		t.setName("TEST");
 		t.setContent("TEST");
@@ -824,7 +828,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testUpdateTemplate() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "templates/1", parametersGet, "templateRetrieve.json", 200);
+		setMockResponse(GET, "templates/1", parametersGet, "templateRetrieve.json", 200);
 		TMTemplate t = client.getResource(TMTemplate.class);
 		try {
 		    t.get(1);
@@ -838,8 +842,8 @@ public class RestClientTest extends BasicTest {
         Map<String, String> parametersPut = new HashMap<String, String>();
         parametersPut.put("name", "TEST1");
         parametersPut.put("content", "TEST1");
-        setMockResponse("PUT", "templates/1", parametersPut, "templateCreateUpdate.json", 201);
-		setMockResponse("GET", "templates/1", parametersGet, "templateRetrieveUpdated.json", 200);
+        setMockResponse(PUT, "templates/1", parametersPut, "templateCreateUpdate.json", 201);
+		setMockResponse(GET, "templates/1", parametersGet, "templateRetrieveUpdated.json", 200);
         t.setName("TEST1");
         t.setContent("TEST1");
         try {
@@ -856,7 +860,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testDeleteTemplate() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "templates/1", parametersGet, "templateRetrieve.json", 200);
+		setMockResponse(GET, "templates/1", parametersGet, "templateRetrieve.json", 200);
 		TMTemplate t = client.getResource(TMTemplate.class);
 		try {
 		    t.get(1);
@@ -865,7 +869,7 @@ public class RestClientTest extends BasicTest {
 		    throw new RuntimeException(e);
 		}
 		Map<String, String> parametersDelete = new HashMap<String, String>();
-		setMockResponse("DELETE", "templates/1", parametersDelete, null, 201);
+		setMockResponse(DELETE, "templates/1", parametersDelete, null, 201);
 		try {
 		    assertTrue(t.delete());
 		} catch (final RestException e) {
@@ -879,7 +883,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "unsubscribers", parameters, "unsubscriberList.json", 200);
+		setMockResponse(GET, "unsubscribers", parameters, "unsubscriberList.json", 200);
 		TMUnsubscriberList ul = client.getResource(TMUnsubscriberList.class);
 		Iterator<TMUnsubscriber> iterator = ul.iterator();
 		assertTrue(iterator.hasNext());
@@ -895,9 +899,9 @@ public class RestClientTest extends BasicTest {
     public void testCreateUnsubscriber() throws Exception {
 		Map<String, String> parametersPost = new HashMap<String, String>();
 		parametersPost.put("phone", "1234567890");
-		setMockResponse("POST", "unsubscribers", parametersPost, "unsubscriberCreateUpdate.json", 201);
+		setMockResponse(POST, "unsubscribers", parametersPost, "unsubscriberCreateUpdate.json", 201);
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "unsubscribers/1", parametersGet, "unsubscriberRetrieve.json", 200);
+		setMockResponse(GET, "unsubscribers/1", parametersGet, "unsubscriberRetrieve.json", 200);
 		TMUnsubscriber u = client.getResource(TMUnsubscriber.class);
 		u.setPhone("1234567890");
 		try {
@@ -915,7 +919,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testUpdateUser() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "user", parametersGet, "userRetrieve.json", 200);
+		setMockResponse(GET, "user", parametersGet, "userRetrieve.json", 200);
 		TMAccount a = client.getResource(TMAccount.class);
 		try {
 		    a.get();
@@ -935,8 +939,8 @@ public class RestClientTest extends BasicTest {
         parametersPut.put("firstName", "TEST1");
         parametersPut.put("lastName", "TEST1");
         parametersPut.put("company", "TEST1");
-        setMockResponse("PUT", "user", parametersPut, "userCreateUpdate.json", 201);
-		setMockResponse("GET", "user", parametersGet, "userRetrieveUpdated.json", 200);
+        setMockResponse(PUT, "user", parametersPut, "userCreateUpdate.json", 201);
+		setMockResponse(GET, "user", parametersGet, "userRetrieveUpdated.json", 200);
         a.setFirstName("TEST1");
         a.setLastName("TEST1");
         a.setCompany("TEST1");
@@ -957,7 +961,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "invoices", parameters, "invoiceList.json", 200);
+		setMockResponse(GET, "invoices", parameters, "invoiceList.json", 200);
 		TMInvoiceList il = client.getResource(TMInvoiceList.class);
 		Iterator<TMInvoice> iterator = il.iterator();
 		assertTrue(iterator.hasNext());
@@ -975,7 +979,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "numbers", parameters, "numberList.json", 200);
+		setMockResponse(GET, "numbers", parameters, "numberList.json", 200);
 		TMNumberList nl = client.getResource(TMNumberList.class);
 		Iterator<TMNumber> iterator = nl.iterator();
 		assertTrue(iterator.hasNext());
@@ -993,7 +997,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("country", "GB");
 		parameters.put("prefix", null);
-		setMockResponse("GET", "numbers/available", parameters, "availableNumberList.json", 200);
+		setMockResponse(GET, "numbers/available", parameters, "availableNumberList.json", 200);
 		TMNumber n = client.getResource(TMNumber.class);
 		List<String> nlist = null;
 		try {
@@ -1011,9 +1015,9 @@ public class RestClientTest extends BasicTest {
 		parameters.put("phone", "1234567890");
 		parameters.put("country", "GB");
 		parameters.put("userId", "1");
-		setMockResponse("POST", "numbers", parameters, "numberCreateUpdate.json", 201);
+		setMockResponse(POST, "numbers", parameters, "numberCreateUpdate.json", 201);
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "numbers/1", parametersGet, "numberRetrieve.json", 200);
+		setMockResponse(GET, "numbers/1", parametersGet, "numberRetrieve.json", 200);
 		TMNumber n = client.getResource(TMNumber.class);
 		n.setCountry("GB");
 		n.setPhone("1234567890");
@@ -1034,7 +1038,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testDeleteNumber() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "numbers/1", parametersGet, "numberRetrieve.json", 200);
+		setMockResponse(GET, "numbers/1", parametersGet, "numberRetrieve.json", 200);
 		TMNumber n = client.getResource(TMNumber.class);
 		try {
 		    n.get(1);
@@ -1043,7 +1047,7 @@ public class RestClientTest extends BasicTest {
 		    throw new RuntimeException(e);
 		}
 		Map<String, String> parametersDelete = new HashMap<String, String>();
-		setMockResponse("DELETE", "numbers/1", parametersDelete, null, 201);
+		setMockResponse(DELETE, "numbers/1", parametersDelete, null, 201);
 		try {
 		    assertTrue(n.delete());
 		} catch (final RestException e) {
@@ -1057,7 +1061,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "senderids", parameters, "senderIdList.json", 200);
+		setMockResponse(GET, "senderids", parameters, "senderIdList.json", 200);
 		TMSenderIdList sl = client.getResource(TMSenderIdList.class);
 		Iterator<TMSenderId> iterator = sl.iterator();
 		assertTrue(iterator.hasNext());
@@ -1074,9 +1078,9 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parametersPost = new HashMap<String, String>();
 		parametersPost.put("senderId", "TEST");
 		parametersPost.put("explanation", "TEST");
-		setMockResponse("POST", "senderids", parametersPost, "senderIdCreateUpdate.json", 201);
+		setMockResponse(POST, "senderids", parametersPost, "senderIdCreateUpdate.json", 201);
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "senderids/1", parametersGet, "senderIdRetrieve.json", 200);
+		setMockResponse(GET, "senderids/1", parametersGet, "senderIdRetrieve.json", 200);
 		TMSenderId s = client.getResource(TMSenderId.class);
 		s.setSenderId("TEST");
 		s.setExplanation("TEST");
@@ -1095,7 +1099,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testDeleteSenderId() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "senderids/1", parametersGet, "senderIdRetrieve.json", 200);
+		setMockResponse(GET, "senderids/1", parametersGet, "senderIdRetrieve.json", 200);
 		TMSenderId s = client.getResource(TMSenderId.class);
 		try {
 		    s.get(1);
@@ -1104,7 +1108,7 @@ public class RestClientTest extends BasicTest {
 		    throw new RuntimeException(e);
 		}
 		Map<String, String> parametersDelete = new HashMap<String, String>();
-		setMockResponse("DELETE", "senderids/1", parametersDelete, null, 201);
+		setMockResponse(DELETE, "senderids/1", parametersDelete, null, 201);
 		try {
 		    assertTrue(s.delete());
 		} catch (final RestException e) {
@@ -1118,7 +1122,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
-		setMockResponse("GET", "subaccounts", parameters, "subaccountList.json", 200);
+		setMockResponse(GET, "subaccounts", parameters, "subaccountList.json", 200);
 		TMSubaccountList sl = client.getResource(TMSubaccountList.class);
 		Iterator<TMSubaccount> iterator = sl.iterator();
 		assertTrue(iterator.hasNext());
@@ -1139,7 +1143,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parametersPost = new HashMap<String, String>();
 		parametersPost.put("email", "TEST");
 		parametersPost.put("role", "U");
-		setMockResponse("POST", "subaccounts", parametersPost, null, 201);
+		setMockResponse(POST, "subaccounts", parametersPost, null, 201);
 		TMSubaccount s = client.getResource(TMSubaccount.class);
 		s.setEmail("TEST");
 		s.setRole("U");
@@ -1154,7 +1158,7 @@ public class RestClientTest extends BasicTest {
 	@Test
     public void testDeleteSubaccount() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "subaccounts/1", parametersGet, "subaccountRetrieve.json", 200);
+		setMockResponse(GET, "subaccounts/1", parametersGet, "subaccountRetrieve.json", 200);
 		TMSubaccount s = client.getResource(TMSubaccount.class);
 		try {
 		    s.get(1);
@@ -1163,7 +1167,7 @@ public class RestClientTest extends BasicTest {
 		    throw new RuntimeException(e);
 		}
 		Map<String, String> parametersDelete = new HashMap<String, String>();
-		setMockResponse("DELETE", "subaccounts/1", parametersDelete, null, 201);
+		setMockResponse(DELETE, "subaccounts/1", parametersDelete, null, 201);
 		try {
 		    assertTrue(s.delete());
 		} catch (final RestException e) {
@@ -1176,7 +1180,7 @@ public class RestClientTest extends BasicTest {
 	@SuppressWarnings("rawtypes")
     public void testSources() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
-		setMockResponse("GET", "sources", parametersGet, "sourceList.json", 200);
+		setMockResponse(GET, "sources", parametersGet, "sourceList.json", 200);
 		TMSourceList sl = client.getResource(TMSourceList.class);
 		@SuppressWarnings("unchecked")
 		List<String> dl = sl.getDedicatedNumbers();
@@ -1199,7 +1203,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("end", "now");
 		parameters.put("page", "1");
 		parameters.put("limit", "10");	
-		setMockResponse("GET", "stats/spending", parameters, "statementList.json", 200);
+		setMockResponse(GET, "stats/spending", parameters, "statementList.json", 200);
 		TMStatementList sl = client.getResource(TMStatementList.class, parameters);
 		Iterator<TMStatement> iterator = sl.iterator();
 		assertTrue(iterator.hasNext());
@@ -1218,7 +1222,7 @@ public class RestClientTest extends BasicTest {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
     public void testMessaging() throws Exception {
 		Map<String, String> parameters = new HashMap<String, String>();	
-		setMockResponse("GET", "stats/messaging", parameters, "messagingList.json", 200);
+		setMockResponse(GET, "stats/messaging", parameters, "messagingList.json", 200);
 		TMMessagingList ml = client.getResource(TMMessagingList.class);
 		Iterator<TMMessaging> iterator = ml.iterator();
 		assertTrue(iterator.hasNext());

--- a/src/test/java/com/textmagic/sdk/RestClientTest.java
+++ b/src/test/java/com/textmagic/sdk/RestClientTest.java
@@ -17,7 +17,7 @@ public class RestClientTest extends BasicTest {
     public void testBulk() throws Exception {
 		Map<String, String> parameters = new HashMap<String, String>();
 		setMockResponse("GET", "bulks/1", parameters, "bulkRetrieve.json", 200);
-        TMBulk b = (TMBulk) client.getResource("TMBulk");
+        TMBulk b = client.getResource(TMBulk.class);
         try {
             b.get(1);
         } catch (final RestException e) {
@@ -38,7 +38,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "bulks", parameters, "bulkList.json", 200);
-		TMBulkList bl = (TMBulkList) client.getResource("TMBulkList");		
+		TMBulkList bl = client.getResource(TMBulkList.class);		
 		Iterator<TMBulk> iterator = bl.iterator();
 		assertTrue(iterator.hasNext());
 		TMBulk b = iterator.next();
@@ -58,7 +58,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("limit", "10");
 		setMockResponse("GET", "chats", parameters, "chatList.json", 200);
 		setMockResponse("GET", "chats/1234567890", parameters, "chatMessageList.json", 200);
-		TMChatList cl = (TMChatList) client.getResource("TMChatList");
+		TMChatList cl = client.getResource(TMChatList.class);
 		Iterator<TMChat> iterator = cl.iterator();
 		assertTrue(iterator.hasNext());
 		TMChat c = iterator.next();
@@ -82,7 +82,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "lists", parameters, "listList.json", 200);
-		TMListList ll = (TMListList) client.getResource("TMListList");		
+		TMListList ll = client.getResource(TMListList.class);		
 		Iterator<TMList> iterator = ll.iterator();
 		assertTrue(iterator.hasNext());
 		TMList l = iterator.next();
@@ -101,7 +101,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "lists/search", parameters, "listList.json", 200);
-		TMListList ll = (TMListList) client.getResource("TMListList", parameters);		
+		TMListList ll = client.getResource(TMListList.class, parameters);
 		Iterator<TMList> iterator = ll.iterator();
 		assertTrue(iterator.hasNext());
 		TMList l = iterator.next();
@@ -121,7 +121,7 @@ public class RestClientTest extends BasicTest {
 		setMockResponse("POST", "lists", parametersPost, "listCreateUpdate.json", 201);
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "lists/1", parametersGet, "listRetrieve.json", 200);
-		TMList l = (TMList) client.getResource("TMList");
+		TMList l = client.getResource(TMList.class);
 		l.setName("TEST");
 		l.setShared(true);
 		try {
@@ -141,7 +141,7 @@ public class RestClientTest extends BasicTest {
     public void testUpdateList() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "lists/1", parametersGet, "listRetrieve.json", 200);
-		TMList l = (TMList) client.getResource("TMList");
+		TMList l = client.getResource(TMList.class);
 		try {
 		    l.get(1);
 		} catch (final RestException e) {
@@ -184,7 +184,7 @@ public class RestClientTest extends BasicTest {
 		setMockResponse("POST", "contacts", parametersPost, "contactCreateUpdate.json", 201);
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "contacts/1", parametersGet, "contactRetrieve.json", 200);
-		TMContact c = (TMContact) client.getResource("TMContact");
+		TMContact c = client.getResource(TMContact.class);
 		c.setFirstName("TEST");
 		c.setLastName("TEST");
 		c.setPhone("1234567890");
@@ -209,7 +209,7 @@ public class RestClientTest extends BasicTest {
 	public void testUpdateListContacts() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "lists/1", parametersGet, "listRetrieve.json", 200);
-		TMList l = (TMList) client.getResource("TMList");
+		TMList l = client.getResource(TMList.class);
 		try {
 		    l.get(1);
 		} catch (final RestException e) {
@@ -226,7 +226,7 @@ public class RestClientTest extends BasicTest {
 	public void testDeleteListContacts() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "lists/1", parametersGet, "listRetrieve.json", 200);
-		TMList l = (TMList) client.getResource("TMList");
+		TMList l = client.getResource(TMList.class);
 		try {
 		    l.get(1);
 		} catch (final RestException e) {
@@ -243,7 +243,7 @@ public class RestClientTest extends BasicTest {
 	public void retrieveListContacts() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "lists/1", parametersGet, "listRetrieve.json", 200);
-		TMList l = (TMList) client.getResource("TMList");
+		TMList l = client.getResource(TMList.class);
 		try {
 		    l.get(1);
 		} catch (final RestException e) {
@@ -272,7 +272,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "contacts", parameters, "contactList.json", 200);
-		TMContactList cl = (TMContactList) client.getResource("TMContactList", parameters);
+		TMContactList cl = client.getResource(TMContactList.class, parameters);
 		Iterator<TMContact> iterator = cl.iterator();
 		assertTrue(iterator.hasNext());
 		TMContact c = iterator.next();
@@ -293,7 +293,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "contacts/search", parameters, "contactList.json", 200);
-		TMContactList cl = (TMContactList) client.getResource("TMContactList", parameters);
+		TMContactList cl = client.getResource(TMContactList.class, parameters);
 		Iterator<TMContact> iterator = cl.iterator();
 		assertTrue(iterator.hasNext());
 		TMContact c = iterator.next();
@@ -311,7 +311,7 @@ public class RestClientTest extends BasicTest {
     public void testUpdateContact() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "contacts/1", parametersGet, "contactRetrieve.json", 200);
-		TMContact c = (TMContact) client.getResource("TMContact");
+		TMContact c = client.getResource(TMContact.class);
 		try {
 		    c.get(1);
 		} catch (final RestException e) {
@@ -359,7 +359,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "customfields", parameters, "customfieldList.json", 200);
-		TMCustomFieldList cfl = (TMCustomFieldList) client.getResource("TMCustomFieldList");
+		TMCustomFieldList cfl = client.getResource(TMCustomFieldList.class);
 		Iterator<TMCustomField> iterator = cfl.iterator();
 		assertTrue(iterator.hasNext());
 		TMCustomField c = iterator.next();
@@ -375,7 +375,7 @@ public class RestClientTest extends BasicTest {
 		setMockResponse("POST", "customfields", parametersPost, "customfieldCreateUpdate.json", 201);
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "customfields/1", parametersGet, "customfieldRetrieve.json", 200);
-		TMCustomField c = (TMCustomField) client.getResource("TMCustomField");
+		TMCustomField c = client.getResource(TMCustomField.class);
 		c.setName("TEST");
 		try {
 		    c.createOrUpdate();
@@ -391,7 +391,7 @@ public class RestClientTest extends BasicTest {
     public void testUpdateCustomField() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "customfields/1", parametersGet, "customfieldRetrieve.json", 200);
-		TMCustomField c = (TMCustomField) client.getResource("TMCustomField");
+		TMCustomField c = client.getResource(TMCustomField.class);
 		try {
 		    c.get(1);
 		} catch (final RestException e) {
@@ -419,7 +419,7 @@ public class RestClientTest extends BasicTest {
     public void testUpdateCustomFieldValue() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "customfields/1", parametersGet, "customfieldRetrieve.json", 200);
-		TMCustomField c = (TMCustomField) client.getResource("TMCustomField");
+		TMCustomField c = client.getResource(TMCustomField.class);
 		try {
 		    c.get(1);
 		} catch (final RestException e) {
@@ -437,7 +437,7 @@ public class RestClientTest extends BasicTest {
     public void testDeleteCustomField() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "customfields/1", parametersGet, "customfieldRetrieve.json", 200);
-		TMCustomField c = (TMCustomField) client.getResource("TMCustomField");
+		TMCustomField c = client.getResource(TMCustomField.class);
 		try {
 		    c.get(1);
 		} catch (final RestException e) {
@@ -458,7 +458,7 @@ public class RestClientTest extends BasicTest {
     public void testDeleteContact() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "contacts/1", parametersGet, "contactRetrieve.json", 200);
-		TMContact c = (TMContact) client.getResource("TMContact");
+		TMContact c = client.getResource(TMContact.class);
 		try {
 		    c.get(1);
 		} catch (final RestException e) {
@@ -481,7 +481,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "messages", parameters, "messageList.json", 200);
-		TMMessageList ml = (TMMessageList) client.getResource("TMMessageList");
+		TMMessageList ml = client.getResource(TMMessageList.class);
 		Iterator<TMMessage> iterator = ml.iterator();
 		assertTrue(iterator.hasNext());
 		TMMessage m = iterator.next();
@@ -499,7 +499,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "messages/search", parameters, "messageList.json", 200);
-		TMMessageList ml = (TMMessageList) client.getResource("TMMessageList", parameters);
+		TMMessageList ml = client.getResource(TMMessageList.class, parameters);
 		Iterator<TMMessage> iterator = ml.iterator();
 		assertTrue(iterator.hasNext());
 		TMMessage m = iterator.next();
@@ -517,7 +517,7 @@ public class RestClientTest extends BasicTest {
 		parametersPost.put("phones", "1234567890");
 		parametersPost.put("dummy", "1");
 		setMockResponse("POST", "messages", parametersPost, "messagePrice.json", 201);
-		TMNewMessage m = (TMNewMessage) client.getResource("TMNewMessage");
+		TMNewMessage m = client.getResource(TMNewMessage.class);
 		m.setText("TEST");
 		m.setPhones(Arrays.asList(new String[] {"1234567890"}));
 		try {
@@ -535,7 +535,7 @@ public class RestClientTest extends BasicTest {
 		parametersPost.put("phones", "1234567890");
 		parametersPost.put("dummy", "0");
 		setMockResponse("POST", "messages", parametersPost, "messageSend.json", 201);
-		TMNewMessage m = (TMNewMessage) client.getResource("TMNewMessage");
+		TMNewMessage m = client.getResource(TMNewMessage.class);
 		m.setText("TEST");
 		m.setPhones(Arrays.asList(new String[] {"1234567890"}));
 		try {
@@ -553,7 +553,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "sessions", parameters, "sessionList.json", 200);
-		TMSessionList sl = (TMSessionList) client.getResource("TMSessionList");
+		TMSessionList sl = client.getResource(TMSessionList.class);
 		Iterator<TMSession> iterator = sl.iterator();
 		assertTrue(iterator.hasNext());
 		TMSession s = iterator.next();
@@ -569,7 +569,7 @@ public class RestClientTest extends BasicTest {
     public void testSession() throws Exception {
 		Map<String, String> parameters = new HashMap<String, String>();
 		setMockResponse("GET", "sessions/1", parameters, "sessionRetrieve.json", 200);
-        TMSession s = (TMSession) client.getResource("TMSession");
+        TMSession s = client.getResource(TMSession.class);
         try {
             s.get(1);
         } catch (final RestException e) {
@@ -587,7 +587,7 @@ public class RestClientTest extends BasicTest {
     public void testMessage() throws Exception {
 		Map<String, String> parameters = new HashMap<String, String>();
 		setMockResponse("GET", "messages/1", parameters, "messageRetrieve.json", 200);
-        TMMessage m = (TMMessage) client.getResource("TMMessage");
+        TMMessage m = client.getResource(TMMessage.class);
         try {
             m.get(1);
         } catch (final RestException e) {
@@ -604,7 +604,7 @@ public class RestClientTest extends BasicTest {
     public void testDeleteMessage() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "messages/1", parametersGet, "messageRetrieve.json", 200);
-		TMMessage m = (TMMessage) client.getResource("TMMessage");
+		TMMessage m = client.getResource(TMMessage.class);
 		try {
 		    m.get(1);
 		} catch (final RestException e) {
@@ -625,7 +625,7 @@ public class RestClientTest extends BasicTest {
     public void testDeleteSession() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "sessions/1", parametersGet, "sessionRetrieve.json", 200);
-		TMSession s = (TMSession) client.getResource("TMSession");
+		TMSession s = client.getResource(TMSession.class);
 		try {
 		    s.get(1);
 		} catch (final RestException e) {
@@ -648,7 +648,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "replies", parameters, "replyList.json", 200);
-		TMReplyList rl = (TMReplyList) client.getResource("TMReplyList");
+		TMReplyList rl = client.getResource(TMReplyList.class);
 		Iterator<TMReply> iterator = rl.iterator();
 		assertTrue(iterator.hasNext());
 		TMReply r = iterator.next();
@@ -666,7 +666,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "replies/search", parameters, "replyList.json", 200);
-		TMReplyList rl = (TMReplyList) client.getResource("TMReplyList", parameters);
+		TMReplyList rl = client.getResource(TMReplyList.class, parameters);
 		Iterator<TMReply> iterator = rl.iterator();
 		assertTrue(iterator.hasNext());
 		TMReply r = iterator.next();
@@ -681,7 +681,7 @@ public class RestClientTest extends BasicTest {
     public void testReply() throws Exception {
 		Map<String, String> parameters = new HashMap<String, String>();
 		setMockResponse("GET", "replies/1", parameters, "replyRetrieve.json", 200);
-        TMReply r = (TMReply) client.getResource("TMReply");
+        TMReply r = client.getResource(TMReply.class);
         try {
             r.get(1);
         } catch (final RestException e) {
@@ -698,7 +698,7 @@ public class RestClientTest extends BasicTest {
     public void testDeleteReply() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "replies/1", parametersGet, "replyRetrieve.json", 200);
-		TMReply r = (TMReply) client.getResource("TMReply");
+		TMReply r = client.getResource(TMReply.class);
 		try {
 		    r.get(1);
 		} catch (final RestException e) {
@@ -721,7 +721,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "schedules", parameters, "scheduleList.json", 200);
-		TMScheduleList sl = (TMScheduleList) client.getResource("TMScheduleList");
+		TMScheduleList sl = client.getResource(TMScheduleList.class);
 		Iterator<TMSchedule> iterator = sl.iterator();
 		assertTrue(iterator.hasNext());
 		TMSchedule s = iterator.next();
@@ -734,7 +734,7 @@ public class RestClientTest extends BasicTest {
     public void testSchedule() throws Exception {
 		Map<String, String> parameters = new HashMap<String, String>();
 		setMockResponse("GET", "schedules/1", parameters, "scheduleRetrieve.json", 200);
-        TMSchedule s = (TMSchedule) client.getResource("TMSchedule");
+        TMSchedule s = client.getResource(TMSchedule.class);
         try {
             s.get(1);
         } catch (final RestException e) {
@@ -749,7 +749,7 @@ public class RestClientTest extends BasicTest {
     public void testDeleteSchedule() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "schedules/1", parametersGet, "scheduleRetrieve.json", 200);
-		TMSchedule s = (TMSchedule) client.getResource("TMSchedule");
+		TMSchedule s = client.getResource(TMSchedule.class);
 		try {
 		    s.get(1);
 		} catch (final RestException e) {
@@ -772,7 +772,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "templates", parameters, "templateList.json", 200);
-		TMTemplateList tl = (TMTemplateList) client.getResource("TMTemplateList");
+		TMTemplateList tl = client.getResource(TMTemplateList.class);
 		Iterator<TMTemplate> iterator = tl.iterator();
 		assertTrue(iterator.hasNext());
 		TMTemplate t = iterator.next();
@@ -789,7 +789,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "templates/search", parameters, "templateList.json", 200);
-		TMTemplateList tl = (TMTemplateList) client.getResource("TMTemplateList", parameters);
+		TMTemplateList tl = client.getResource(TMTemplateList.class, parameters);
 		Iterator<TMTemplate> iterator = tl.iterator();
 		assertTrue(iterator.hasNext());
 		TMTemplate t = iterator.next();
@@ -807,7 +807,7 @@ public class RestClientTest extends BasicTest {
 		setMockResponse("POST", "templates", parametersPost, "templateCreateUpdate.json", 201);
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "templates/1", parametersGet, "templateRetrieve.json", 200);
-		TMTemplate t = (TMTemplate) client.getResource("TMTemplate");
+		TMTemplate t = client.getResource(TMTemplate.class);
 		t.setName("TEST");
 		t.setContent("TEST");
 		try {
@@ -825,7 +825,7 @@ public class RestClientTest extends BasicTest {
     public void testUpdateTemplate() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "templates/1", parametersGet, "templateRetrieve.json", 200);
-		TMTemplate t = (TMTemplate) client.getResource("TMTemplate");
+		TMTemplate t = client.getResource(TMTemplate.class);
 		try {
 		    t.get(1);
 		} catch (final RestException e) {
@@ -857,7 +857,7 @@ public class RestClientTest extends BasicTest {
     public void testDeleteTemplate() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "templates/1", parametersGet, "templateRetrieve.json", 200);
-		TMTemplate t = (TMTemplate) client.getResource("TMTemplate");
+		TMTemplate t = client.getResource(TMTemplate.class);
 		try {
 		    t.get(1);
 		} catch (final RestException e) {
@@ -880,7 +880,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "unsubscribers", parameters, "unsubscriberList.json", 200);
-		TMUnsubscriberList ul = (TMUnsubscriberList) client.getResource("TMUnsubscriberList");
+		TMUnsubscriberList ul = client.getResource(TMUnsubscriberList.class);
 		Iterator<TMUnsubscriber> iterator = ul.iterator();
 		assertTrue(iterator.hasNext());
 		TMUnsubscriber u = iterator.next();
@@ -898,7 +898,7 @@ public class RestClientTest extends BasicTest {
 		setMockResponse("POST", "unsubscribers", parametersPost, "unsubscriberCreateUpdate.json", 201);
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "unsubscribers/1", parametersGet, "unsubscriberRetrieve.json", 200);
-		TMUnsubscriber u = (TMUnsubscriber) client.getResource("TMUnsubscriber");
+		TMUnsubscriber u = client.getResource(TMUnsubscriber.class);
 		u.setPhone("1234567890");
 		try {
 		    u.createOrUpdate();
@@ -916,7 +916,7 @@ public class RestClientTest extends BasicTest {
     public void testUpdateUser() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "user", parametersGet, "userRetrieve.json", 200);
-		TMAccount a = (TMAccount) client.getResource("TMAccount");
+		TMAccount a = client.getResource(TMAccount.class);
 		try {
 		    a.get();
 		} catch (final RestException e) {
@@ -958,7 +958,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "invoices", parameters, "invoiceList.json", 200);
-		TMInvoiceList il = (TMInvoiceList) client.getResource("TMInvoiceList");
+		TMInvoiceList il = client.getResource(TMInvoiceList.class);
 		Iterator<TMInvoice> iterator = il.iterator();
 		assertTrue(iterator.hasNext());
 		TMInvoice i = iterator.next();
@@ -976,7 +976,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "numbers", parameters, "numberList.json", 200);
-		TMNumberList nl = (TMNumberList) client.getResource("TMNumberList");
+		TMNumberList nl = client.getResource(TMNumberList.class);
 		Iterator<TMNumber> iterator = nl.iterator();
 		assertTrue(iterator.hasNext());
 		TMNumber n = iterator.next();
@@ -994,7 +994,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("country", "GB");
 		parameters.put("prefix", null);
 		setMockResponse("GET", "numbers/available", parameters, "availableNumberList.json", 200);
-		TMNumber n = (TMNumber) client.getResource("TMNumber");
+		TMNumber n = client.getResource(TMNumber.class);
 		List<String> nlist = null;
 		try {
 		    nlist = n.getAvailableNumbers("GB", null);
@@ -1014,7 +1014,7 @@ public class RestClientTest extends BasicTest {
 		setMockResponse("POST", "numbers", parameters, "numberCreateUpdate.json", 201);
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "numbers/1", parametersGet, "numberRetrieve.json", 200);
-		TMNumber n = (TMNumber) client.getResource("TMNumber");
+		TMNumber n = client.getResource(TMNumber.class);
 		n.setCountry("GB");
 		n.setPhone("1234567890");
 		n.setUserId(1);
@@ -1035,7 +1035,7 @@ public class RestClientTest extends BasicTest {
     public void testDeleteNumber() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "numbers/1", parametersGet, "numberRetrieve.json", 200);
-		TMNumber n = (TMNumber) client.getResource("TMNumber");
+		TMNumber n = client.getResource(TMNumber.class);
 		try {
 		    n.get(1);
 		} catch (final RestException e) {
@@ -1058,7 +1058,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "senderids", parameters, "senderIdList.json", 200);
-		TMSenderIdList sl = (TMSenderIdList) client.getResource("TMSenderIdList");
+		TMSenderIdList sl = client.getResource(TMSenderIdList.class);
 		Iterator<TMSenderId> iterator = sl.iterator();
 		assertTrue(iterator.hasNext());
 		TMSenderId s = iterator.next();
@@ -1077,7 +1077,7 @@ public class RestClientTest extends BasicTest {
 		setMockResponse("POST", "senderids", parametersPost, "senderIdCreateUpdate.json", 201);
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "senderids/1", parametersGet, "senderIdRetrieve.json", 200);
-		TMSenderId s = (TMSenderId) client.getResource("TMSenderId");
+		TMSenderId s = client.getResource(TMSenderId.class);
 		s.setSenderId("TEST");
 		s.setExplanation("TEST");
 		try {
@@ -1096,7 +1096,7 @@ public class RestClientTest extends BasicTest {
     public void testDeleteSenderId() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "senderids/1", parametersGet, "senderIdRetrieve.json", 200);
-		TMSenderId s = (TMSenderId) client.getResource("TMSenderId");
+		TMSenderId s = client.getResource(TMSenderId.class);
 		try {
 		    s.get(1);
 		} catch (final RestException e) {
@@ -1119,7 +1119,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");
 		setMockResponse("GET", "subaccounts", parameters, "subaccountList.json", 200);
-		TMSubaccountList sl = (TMSubaccountList) client.getResource("TMSubaccountList");
+		TMSubaccountList sl = client.getResource(TMSubaccountList.class);
 		Iterator<TMSubaccount> iterator = sl.iterator();
 		assertTrue(iterator.hasNext());
 		TMSubaccount s = iterator.next();
@@ -1140,7 +1140,7 @@ public class RestClientTest extends BasicTest {
 		parametersPost.put("email", "TEST");
 		parametersPost.put("role", "U");
 		setMockResponse("POST", "subaccounts", parametersPost, null, 201);
-		TMSubaccount s = (TMSubaccount) client.getResource("TMSubaccount");
+		TMSubaccount s = client.getResource(TMSubaccount.class);
 		s.setEmail("TEST");
 		s.setRole("U");
 		try {
@@ -1155,7 +1155,7 @@ public class RestClientTest extends BasicTest {
     public void testDeleteSubaccount() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "subaccounts/1", parametersGet, "subaccountRetrieve.json", 200);
-		TMSubaccount s = (TMSubaccount) client.getResource("TMSubaccount");
+		TMSubaccount s = client.getResource(TMSubaccount.class);
 		try {
 		    s.get(1);
 		} catch (final RestException e) {
@@ -1177,7 +1177,7 @@ public class RestClientTest extends BasicTest {
     public void testSources() throws Exception {
 		Map<String, String> parametersGet = new HashMap<String, String>();
 		setMockResponse("GET", "sources", parametersGet, "sourceList.json", 200);
-		TMSourceList sl = (TMSourceList) client.getResource("TMSourceList");
+		TMSourceList sl = client.getResource(TMSourceList.class);
 		@SuppressWarnings("unchecked")
 		List<String> dl = sl.getDedicatedNumbers();
 		@SuppressWarnings("unchecked")
@@ -1200,7 +1200,7 @@ public class RestClientTest extends BasicTest {
 		parameters.put("page", "1");
 		parameters.put("limit", "10");	
 		setMockResponse("GET", "stats/spending", parameters, "statementList.json", 200);
-		TMStatementList sl = (TMStatementList) client.getResource("TMStatementList", parameters);
+		TMStatementList sl = client.getResource(TMStatementList.class, parameters);
 		Iterator<TMStatement> iterator = sl.iterator();
 		assertTrue(iterator.hasNext());
 		TMStatement s = iterator.next();
@@ -1219,7 +1219,7 @@ public class RestClientTest extends BasicTest {
     public void testMessaging() throws Exception {
 		Map<String, String> parameters = new HashMap<String, String>();	
 		setMockResponse("GET", "stats/messaging", parameters, "messagingList.json", 200);
-		TMMessagingList ml = (TMMessagingList) client.getResource("TMMessagingList");
+		TMMessagingList ml = client.getResource(TMMessagingList.class);
 		Iterator<TMMessaging> iterator = ml.iterator();
 		assertTrue(iterator.hasNext());
 		TMMessaging m = iterator.next();

--- a/src/test/java/com/textmagic/sdk/RestClientTest.java
+++ b/src/test/java/com/textmagic/sdk/RestClientTest.java
@@ -533,8 +533,7 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parametersPost = new HashMap<String, String>();
 		parametersPost.put("text", "TEST");
 		parametersPost.put("phones", "1234567890");
-		parametersPost.put("dummy", "1");
-		setMockResponse(POST, "messages", parametersPost, "messagePrice.json", 201);
+		setMockResponse(GET, "messages/price", parametersPost, "messagePrice.json", 201);
 		TMNewMessage m = client.getResource(TMNewMessage.class);
 		m.setText("TEST");
 		m.setPhones(Arrays.asList(new String[] {"1234567890"}));
@@ -551,7 +550,6 @@ public class RestClientTest extends BasicTest {
 		Map<String, String> parametersPost = new HashMap<String, String>();
 		parametersPost.put("text", "TEST");
 		parametersPost.put("phones", "1234567890");
-		parametersPost.put("dummy", "0");
 		setMockResponse(POST, "messages", parametersPost, "messageSend.json", 201);
 		TMNewMessage m = client.getResource(TMNewMessage.class);
 		m.setText("TEST");

--- a/src/test/java/com/textmagic/sdk/RestClientTest.java
+++ b/src/test/java/com/textmagic/sdk/RestClientTest.java
@@ -20,14 +20,15 @@ public class RestClientTest extends BasicTest {
 
 	@Test
 	public void testEndpointSelectionTest() {
-		client = new RestClient("user", "token", RestClient.TESTING_URI);
-		assertTrue(client.getApiUri().startsWith("https://api.textmagictesting.com"));
+		client = new RestClient("user", "token");
+		assertTrue(client.getApiUri().startsWith(RestClient.PRODUCTION_URI));
 	}
 
 	@Test
 	public void testEndpointSelectionProduction() {
-		client = new RestClient("user", "token", RestClient.PRODUCTION_URI);
-		assertTrue(client.getApiUri().startsWith("https://api.textmagic.com"));
+		String testURI = "https://api.test.api/";
+		client = new RestClient("user", "token", "https://api.test.api/");
+		assertEquals(testURI, client.getApiUri());
 	}
 
 	@Test


### PR DESCRIPTION
1. Fixed Java 6 & Java 7 compatibility
2. Created unchecked exception for failure within wrapper itself
3. Made resouce creation type-safe.
4. Changed request type from string to enum
5. Made API URL configurable
   6, Fixed error handling, which used to fail for some requests depending on error structure
6. Fixed sendMessage & getPrice methods - removed dummy parameter and added 'total' conversion to double
